### PR TITLE
Update Gem to work with all Solidus versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: required
 dist: trusty
 cache: bundler
 language: ruby
+addons:
+  chrome: stable
 rvm:
-  - 2.3.1
+  - 2.5.1
 before_install:
   - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,17 @@ before_install:
   - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';"
 env:
   matrix:
-    - SOLIDUS_BRANCH=v1.1 DB=postgres
-    - SOLIDUS_BRANCH=v1.2 DB=postgres
-    - SOLIDUS_BRANCH=v1.3 DB=postgres
-    - SOLIDUS_BRANCH=v1.4 DB=postgres
-    - SOLIDUS_BRANCH=v2.0 DB=postgres
-    - SOLIDUS_BRANCH=v2.1 DB=postgres
     - SOLIDUS_BRANCH=v2.2 DB=postgres
     - SOLIDUS_BRANCH=v2.3 DB=postgres
     - SOLIDUS_BRANCH=v2.4 DB=postgres
+    - SOLIDUS_BRANCH=v2.5 DB=postgres
+    - SOLIDUS_BRANCH=v2.6 DB=postgres
+    - SOLIDUS_BRANCH=v2.7 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
-    - SOLIDUS_BRANCH=v1.1 DB=mysql
-    - SOLIDUS_BRANCH=v1.2 DB=mysql
-    - SOLIDUS_BRANCH=v1.3 DB=mysql
-    - SOLIDUS_BRANCH=v1.4 DB=mysql
-    - SOLIDUS_BRANCH=v2.0 DB=mysql
-    - SOLIDUS_BRANCH=v2.1 DB=mysql
     - SOLIDUS_BRANCH=v2.2 DB=mysql
     - SOLIDUS_BRANCH=v2.3 DB=mysql
     - SOLIDUS_BRANCH=v2.4 DB=mysql
+    - SOLIDUS_BRANCH=v2.5 DB=mysql
+    - SOLIDUS_BRANCH=v2.6 DB=mysql
+    - SOLIDUS_BRANCH=v2.7 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,16 @@ source "https://rubygems.org"
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+group :test do
+  if branch == 'master' || branch >= "v2.0"
+    gem "rails-controller-testing"
+  end
+
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
 end
 
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :test do
   else
     gem 'factory_bot', '> 4.10.0'
   end
+
+  gem 'chromedriver-helper' if ENV['CI']
 end
 
 gem 'pg'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Solidus Stripe
 ===============
 
+[![Build Status](https://travis-ci.org/solidusio-contrib/solidus_stripe.svg?branch=master)](https://travis-ci.org/solidusio-contrib/solidus_stripe)
+
 Stripe Payment Method for Solidus. It works as a wrapper for the ActiveMerchant Stripe gateway.
 
 ---

--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::StripeGateway < Gateway
+  class Gateway::StripeGateway < SolidusSupport.payment_method_parent_class(credit_card: true)
     preference :secret_key, :string
     preference :publishable_key, :string
 

--- a/db/migrate/20130213222555_update_stripe_payment_method_type.rb
+++ b/db/migrate/20130213222555_update_stripe_payment_method_type.rb
@@ -1,9 +1,0 @@
-class UpdateStripePaymentMethodType < SolidusSupport::Migration[4.2]
-  def up
-    Spree::PaymentMethod.where(:type => "Spree::Gateway::Stripe").update_all(:type => "Spree::Gateway::StripeGateway")
-  end
-  
-  def down
-    Spree::PaymentMethod.where(:type => "Spree::Gateway::StripeGateway").update_all(:type => "Spree::Gateway::Stripe")
-  end
-end

--- a/db/migrate/20131112133401_migrate_stripe_preferences.rb
+++ b/db/migrate/20131112133401_migrate_stripe_preferences.rb
@@ -1,8 +1,0 @@
-class MigrateStripePreferences < SolidusSupport::Migration[4.2]
-  def up
-    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name("key")} LIKE 'spree/gateway/stripe_gateway/login%'").each do |pref|
-      pref.key = pref.key.gsub('login', 'secret_key')
-      pref.save
-    end
-  end
-end

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"
   s.add_development_dependency "poltergeist", "~> 1.9"
+  s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "database_cleaner", "~> 1.5"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 
 require 'solidus_support/extension/feature_helper'
 
+require 'selenium-webdriver'
+Capybara.javascript_driver = :selenium_chrome_headless
+
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 Capybara.server = :webrick

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ require 'solidus_support/extension/feature_helper'
 
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
+Capybara.server = :webrick
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
This PR:

- updates travis config to test against relevant versions of Solidus + add badge in the README
- update rspec config to have feature specs working
- update factory_bot dependency to be able to test against solidus 2.2
- use `SolidusSupport.payment_method_parent_class` so Stripe Gateway works with all Solidus versions