### PR TITLE
Allow creating seeds with the install command

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+secret_key = ENV['STRIPE_SEEDS_SECRET_KEY']
+publishable_key = ENV['STRIPE_SEEDS_PUBLISHABLE_KEY']
+
+puts "Loading seed: solidus_stripe/stripe_payment_method"
+
+if secret_key.blank? || publishable_key.blank?
+  puts "Failure: You have to set both STRIPE_SEEDS_SECRET_KEY and STRIPE_SEEDS_PUBLISHABLE_KEY environment variables."
+else
+  stripe_payment_method = Spree::PaymentMethod::StripeCreditCard.new do |payment_method|
+    payment_method.name = 'Credit Card'
+    payment_method.preferred_test_mode = true
+    payment_method.preferred_secret_key = secret_key
+    payment_method.preferred_publishable_key = publishable_key
+  end
+
+  if stripe_payment_method.save
+    puts "Stripe Payment Method correctly created."
+  else
+    puts "There was some problems with creating Stripe Payment Method:"
+    stripe_payment_method.errors.full_messages.each do |error|
+      puts error
+    end
+  end
+end

--- a/lib/generators/solidus_stripe/install/install_generator.rb
+++ b/lib/generators/solidus_stripe/install/install_generator.rb
@@ -1,18 +1,29 @@
+# frozen_string_literal: true
+
 module SolidusStripe
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      class_option :migrate, type: :boolean, default: true
       class_option :auto_run_migrations, type: :boolean, default: false
+      class_option :auto_run_seeds, type: :boolean, default: false
 
       def add_migrations
         run 'bundle exec rake railties:install:migrations FROM=solidus_stripe'
       end
 
       def run_migrations
-        if running_migrations?
+        if options.migrate? && running_migrations?
           run 'bundle exec rake db:migrate'
         else
           puts "Skiping rake db:migrate, don't forget to run it!"
         end
+      end
+
+      def populate_seed_data
+        return unless options.auto_run_seeds?
+
+        say_status :loading, 'stripe seed data'
+        rake('db:seed:solidus_stripe')
       end
 
       private

--- a/lib/tasks/solidus_stripe/db/seed.rake
+++ b/lib/tasks/solidus_stripe/db/seed.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    desc 'Loads stripe sample data'
+    task solidus_stripe: :environment do
+      seed_file = Dir[SolidusStripe::Engine.root.join('db', 'seeds.rb')][0]
+      return unless File.exist?(seed_file)
+
+      puts "Seeding #{seed_file}..."
+      load(seed_file)
+    end
+  end
+end


### PR DESCRIPTION
This PR allows to call:

```
STRIPE_SEEDS_SECRET_KEY=xxx \
STRIPE_SEEDS_PUBLISHABLE_KEY=yyy \
bundle exec rails g solidus_stripe:install --migrate=false --auto_run_seeds=true
```

to run seeds along with the engine installation. This could be useful in the to allow using stripe in the core sandbox if we decide to go on that path for https://github.com/solidusio/solidus/issues/3162.