### PR TITLE
Add Rubocop for linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,319 @@
+# Relaxed.Ruby.Style
+
+AllCops:
+  Exclude:
+    - 'spec/dummy/**/*'
+    - 'bin/**'
+  TargetRubyVersion: 2.2
+
+# Sometimes I believe this reads better
+# This also causes spacing issues on multi-line fixes
+Style/BracesAroundHashParameters:
+  Enabled: false
+
+# We use class vars and will have to continue doing so for compatability
+Style/ClassVars:
+  Enabled: false
+
+# We need these names for backwards compatability
+Naming/PredicateName:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+# This has been used for customization
+Style/MutableConstant:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/EmptyElse:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Performance/Count:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+# We can use good judgement here
+Style/RegexpLiteral:
+  Enabled: false
+
+# Unicode comments are useful
+Style/AsciiComments:
+  Enabled: false
+
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/IndentArray:
+  Enabled: false
+
+Layout/IndentHash:
+  Enabled: false
+
+Layout/AlignHash:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+# Symbol Arrays are ok and the %i syntax widely unknown
+Style/SymbolArray:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Whitelist:
+    - find_by_param
+    - find_by_param!
+
+# We use a lot of
+#
+#     expect {
+#       something
+#     }.to { happen }
+#
+# syntax in the specs files.
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - '*/spec/**/*'
+    - 'spec/**/*' # For the benefit of apps that inherit from this config
+
+# We use eval to add common_spree_dependencies into the Gemfiles of each of our gems
+Security/Eval:
+  Exclude:
+    - 'Gemfile'
+    - 'common_spree_dependencies.rb'
+    - '*/Gemfile'
+
+Naming/VariableNumber:
+  Enabled: false
+
+# Write empty methods as you wish.
+Style/EmptyMethod:
+  Enabled: false
+
+# From http://relaxed.ruby.style/
+
+Style/Alias:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylealias
+
+Style/BeginBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylebeginblock
+
+Style/BlockDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleblockdelimiters
+
+Style/Documentation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledocumentation
+
+Layout/DotPosition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledotposition
+
+Style/DoubleNegation:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styledoublenegation
+
+Style/EndBlock:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleendblock
+
+Style/FormatString:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleformatstring
+
+Style/IfUnlessModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleifunlessmodifier
+
+Style/Lambda:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylelambda
+
+Style/ModuleFunction:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemodulefunction
+
+Style/MultilineBlockChain:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylemultilineblockchain
+
+Style/NegatedIf:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedif
+
+Style/NegatedWhile:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylenegatedwhile
+
+Style/ParallelAssignment:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleparallelassignment
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylepercentliteraldelimiters
+
+Style/PerlBackrefs:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#styleperlbackrefs
+
+Style/Semicolon:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesemicolon
+
+Style/SignalException:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesignalexception
+
+Style/SingleLineBlockParams:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelineblockparams
+
+Style/SingleLineMethods:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylesinglelinemethods
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces
+
+Layout/SpaceInsideParens:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespaceinsideparens
+
+Style/SpecialGlobalVars:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylespecialglobalvars
+
+Style/StringLiterals:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylestringliterals
+
+Style/SymbolProc:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#stylewhileuntilmodifier
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintambiguousregexpliteral
+
+Lint/AssignmentInCondition:
+  Enabled: false
+  StyleGuide: http://relaxed.ruby.style/#lintassignmentincondition
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+# json.() is idiomatic in jbuilder files
+Style/LambdaCall:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  AllowedNames:
+    - id
+    - to
+    - _
+
+# Rubocop doesn't understand side-effects
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Lint/UselessComparison:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')

--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,7 @@ group :test do
     gem "rails-controller-testing"
   end
 
-  if branch < "v2.5"
-    gem 'factory_bot', '4.10.0'
-  else
-    gem 'factory_bot', '> 4.10.0'
-  end
+  gem 'factory_bot', (branch < 'v2.5' ? '4.10.0' : '> 4.10.0')
 
   gem 'chromedriver-helper' if ENV['CI']
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spree
   class PaymentMethod
     class StripeCreditCard < Spree::PaymentMethod::CreditCard
@@ -48,6 +50,7 @@ module Spree
 
       def create_profile(payment)
         return unless payment.source.gateway_customer_profile_id.nil?
+
         options = {
           email: payment.order.email,
           login: preferred_secret_key,
@@ -78,7 +81,7 @@ module Spree
       # In this gateway, what we call 'secret_key' is the 'login'
       def options
         options = super
-        options.merge(:login => preferred_secret_key)
+        options.merge(login: preferred_secret_key)
       end
 
       def options_for_purchase_or_auth(money, creditcard, transaction_options)
@@ -95,21 +98,21 @@ module Spree
           # https://github.com/Shopify/active_merchant/issues/770
           creditcard = token_or_card_id
         end
-        return money, creditcard, options
+        [money, creditcard, options]
       end
 
       def address_for(payment)
         {}.tap do |options|
           if address = payment.order.bill_address
-            options.merge!(address: {
+            options[:address] = {
               address1: address.address1,
               address2: address.address2,
               city: address.city,
               zip: address.zipcode
-            })
+            }
 
             if country = address.country
-              options[:address].merge!(country: country.name)
+              options[:address][:country] = country.name
             end
 
             if state = address.state

--- a/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
+++ b/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateStripePaymentMethodTypeToCreditCard < SolidusSupport::Migration[5.1]
   def up
     Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway').update_all(type: 'Spree::PaymentMethod::StripeCreditCard')

--- a/lib/generators/solidus_stripe/install/install_generator.rb
+++ b/lib/generators/solidus_stripe/install/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusStripe
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/solidus_stripe.rb
+++ b/lib/solidus_stripe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_merchant"
 require "solidus_core"
 require "solidus_support"

--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusStripe
   class Engine < Rails::Engine
     engine_name 'solidus_stripe'
@@ -16,6 +18,6 @@ module SolidusStripe
 
     if SolidusSupport.api_available?
       paths["app/views"] << "lib/views/api"
-    end    
+    end
   end
 end

--- a/lib/solidus_stripe/version.rb
+++ b/lib/solidus_stripe/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusStripe
   VERSION = "1.0.0"
 end

--- a/lib/views/api/spree/api/payments/source_views/_stripe.json.jbuilder
+++ b/lib/views/api/spree/api/payments/source_views/_stripe.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
- json.partial!('spree/api/payments/source_views/gateway', payment_source: payment_source)
+json.partial!('spree/api/payments/source_views/gateway', payment_source: payment_source)

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.version     = SolidusStripe::VERSION
   s.summary     = "Stripe Payment Method for Solidus"
   s.description = s.summary
-  s.required_ruby_version = ">= 2.1"
+  s.required_ruby_version = ">= 2.2"
 
   s.author       = "Solidus Team"
   s.email        = "contact@solidus.io"

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -1,5 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'solidus_stripe/version'
 
@@ -16,7 +17,7 @@ Gem::Specification.new do |s|
   s.author       = "Solidus Team"
   s.email        = "contact@solidus.io"
   s.homepage     = "https://solidus.io"
-  s.license      = %q{BSD-3}
+  s.license      = 'BSD-3'
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")
@@ -32,13 +33,13 @@ Gem::Specification.new do |s|
   # This was resolved in v1.60, but we still need to skip 1.58 & 1.59.
   s.add_dependency "activemerchant", "~> 1.48", "!= 1.58.0", "!= 1.59.0"
 
-  s.add_development_dependency "rspec-rails", "~> 3.2"
-  s.add_development_dependency "simplecov"
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "factory_bot", "~> 4.4"
   s.add_development_dependency "capybara"
   s.add_development_dependency "capybara-screenshot"
-  s.add_development_dependency "poltergeist", "~> 1.9"
-  s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "database_cleaner", "~> 1.5"
+  s.add_development_dependency "factory_bot", "~> 4.4"
+  s.add_development_dependency "poltergeist", "~> 1.9"
+  s.add_development_dependency "rspec-rails", "~> 3.2"
+  s.add_development_dependency "selenium-webdriver"
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "sqlite3"
 end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe "Stripe checkout", type: :feature do

--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Spree::PaymentMethod::StripeCreditCard do
@@ -10,9 +12,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
       source: source,
       order: double('Spree::Order',
         email: email,
-        bill_address: bill_address
-      )
-    )
+        bill_address: bill_address))
   }
 
   let(:gateway) do
@@ -25,7 +25,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
 
   before do
     subject.preferences = { secret_key: secret_key }
-    allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
+    allow(subject).to receive(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
     allow(subject).to receive(:gateway).and_return gateway
   end
 
@@ -42,8 +42,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
           city: 'Suzarac',
           zipcode: '95671',
           state: double('Spree::State', name: 'Oregon'),
-          country: double('Spree::Country', name: 'United States')
-        )
+          country: double('Spree::Country', name: 'United States'))
       }
 
       it 'stores the bill address with the gateway' do
@@ -122,7 +121,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
 
     it 'send the payment to the gateway' do
-      expect(gateway).to receive(:purchase).with('money','cc','opts')
+      expect(gateway).to receive(:purchase).with('money', 'cc', 'opts')
     end
   end
 
@@ -132,32 +131,31 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
 
     it 'send the authorization to the gateway' do
-      expect(gateway).to receive(:authorize).with('money','cc','opts')
+      expect(gateway).to receive(:authorize).with('money', 'cc', 'opts')
     end
   end
 
   context 'capturing' do
-
     after do
       subject.capture(1234, 'response_code', {})
     end
 
     it 'convert the amount to cents' do
-      expect(gateway).to receive(:capture).with(1234,anything,anything)
+      expect(gateway).to receive(:capture).with(1234, anything, anything)
     end
 
     it 'use the response code as the authorization' do
-      expect(gateway).to receive(:capture).with(anything,'response_code',anything)
+      expect(gateway).to receive(:capture).with(anything, 'response_code', anything)
     end
   end
 
   context 'capture with payment class' do
     let(:payment_method) do
-      payment_method = described_class.new(:active => true)
+      payment_method = described_class.new(active: true)
       payment_method.set_preference :secret_key, secret_key
-      allow(payment_method).to receive(:options_for_purchase_or_auth).and_return(['money','cc','opts'])
+      allow(payment_method).to receive(:options_for_purchase_or_auth).and_return(['money', 'cc', 'opts'])
       allow(payment_method).to receive(:gateway).and_return gateway
-      allow(payment_method).to receive_messages :source_required => true
+      allow(payment_method).to receive_messages source_required: true
       payment_method
     end
 
@@ -184,10 +182,10 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
 
     let!(:success_response) do
-      double('success_response', :success? => true,
-                               :authorization => '123',
-                               :avs_result => { 'code' => 'avs-code' },
-                               :cvv_result => { 'code' => 'cvv-code', 'message' => "CVV Result"})
+      double('success_response', success?: true,
+                               authorization: '123',
+                               avs_result: { 'code' => 'avs-code' },
+                               cvv_result: { 'code' => 'cvv-code', 'message' => "CVV Result" })
     end
 
     after do
@@ -195,7 +193,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
 
     it 'gets correct amount' do
-      expect(gateway).to receive(:capture).with(9855,'12345',anything).and_return(success_response)
+      expect(gateway).to receive(:capture).with(9855, '12345', anything).and_return(success_response)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start "rails"
 
 ENV["RAILS_ENV"] ||= "test"
 
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require File.expand_path('dummy/config/environment.rb', __dir__)
 
 require 'solidus_support/extension/feature_helper'
 


### PR DESCRIPTION
In an effort to improve tooling and to achieve a more consistent development environment, this PR aims to include Rubocop to this gem, as well as fix all the offenses based on the [Rubocop config file](https://github.com/solidusio/solidus/blob/master/.rubocop.yml) that Solidus uses.