### PR TITLE
Remove Capybara deprecation warning

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Stripe checkout", type: :feature do
       fill_in "Street Address", with: "YT-1300"
       fill_in "City", with: "Mos Eisley"
       select "United States of America", from: "Country"
-      select country.states.first, from: "order_bill_address_attributes_state_id"
+      select country.states.first.name, from: "order_bill_address_attributes_state_id"
       fill_in "Zip", with: "12010"
       fill_in "Phone", with: "(555) 555-5555"
     end


### PR DESCRIPTION
Capybara requires options selector to be a string or a symbol starting from the
next (relative to this bundle) version.