### PR TITLE
Remove `Spree.t` in favor of `I18n.t`

### DIFF
--- a/lib/views/backend/spree/admin/log_entries/_stripe.html.erb
+++ b/lib/views/backend/spree/admin/log_entries/_stripe.html.erb
@@ -1,28 +1,28 @@
 <tr>
-  <td><%= Spree.t(:message, :scope => [:log_entry, :stripe]) %></td>
+  <td><%= t(:message, :scope => [:spree, :log_entry, :stripe]) %></td>
   <td><%= entry.parsed_details.message %></td>
 </tr>
 <tr>
-  <td><%= Spree.t(:charge_id, :scope => [:log_entry, :stripe]) %></td>
+  <td><%= t(:charge_id, :scope => [:spree, :log_entry, :stripe]) %></td>
   <td><%= entry.parsed_details.params['id'] %></td>
 </tr>
 <% if card = entry.parsed_details.params['card'] %>
   <tr>
-    <td><%= Spree.t(:card_id, :scope => [:log_entry, :stripe]) %></td>
+    <td><%= t(:card_id, :scope => [:spree, :log_entry, :stripe]) %></td>
     <td><%= card['id'] %></td>
   </tr>
 
   <tr>
-    <td><%= Spree.t(:cvc_check, :scope => [:log_entry, :stripe]) %></td>
+    <td><%= t(:cvc_check, :scope => [:spree, :log_entry, :stripe]) %></td>
     <td><%= card['cvc_check'] %></td>
   </tr>
 
   <tr>
-    <td><%= Spree.t(:address_zip_check, :scope => [:log_entry, :stripe]) %></td>
+    <td><%= t(:address_zip_check, :scope => [:spree, :log_entry, :stripe]) %></td>
     <td><%= card['address_zip_check'] %></td>
   </tr>
 <% end %>
 <tr>
-  <td><%= Spree.t(:cvv_result, :scope => [:log_entry, :stripe]) %></td>
+  <td><%= t(:cvv_result, :scope => [:spree, :log_entry, :stripe]) %></td>
   <td><%= entry.parsed_details.cvv_result['message'].to_s %></td>
 </tr>


### PR DESCRIPTION
`Spree.t` has been deprecated on the whole Solidus ecosystem.