### PR TITLE
Use preferred_v3_elements instead of preferences[:v3_elements]

### DIFF
--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def v3_elements?
-        !!preferences[:v3_elements]
+        !!preferred_v3_elements
       end
 
       def gateway_class


### PR DESCRIPTION
Using static model preferences, the line `preferences[:v3_elements]` throws a
```ruby
undefined method '[]' for #<Spree::Preferences::StaticModelPreferences::Definition:0x00007fb3c8a9b1a8>
```
so I had to change it to `preferred_v3_elements`.