### PR TITLE
Update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 In your Gemfile:
 
 ```ruby
-gem "solidus_stripe"
+gem "solidus_stripe", github: "solidusio-contrib/solidus_stripe"
 ```
 
 Then run from the command line:


### PR DESCRIPTION
It appears that this gem is not currently hosted on rubygems, so the installation instructions on the README should be updated so users know they should install from GitHub.

Related to this issue: https://github.com/solidusio-contrib/solidus_stripe/issues/4
