### PR TITLE
Allow Apple Pay and Google Pay via Payment Request Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Spree.config do |config|
     'stripe_env_credentials',
     secret_key: ENV['STRIPE_SECRET_KEY'],
     publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
+    stripe_country: 'US',
     v3_elements: false,
     v3_intents: false,
     server: Rails.env.production? ? 'production' : 'test',
@@ -67,11 +68,16 @@ Source field a new entry called `stripe_env_credentials`. After saving,
 your  application will start using the static configuration to process
 Stripe payments.
 
+
 Using Stripe Payment Intents API
 --------------------------------
 
 If you want to use the new SCA-ready Stripe Payment Intents API you need
-to change the `v3_intents` preference from the code above to true:
+to change the `v3_intents` preference from the code above to true and,
+if you want to allow also Apple Pay and Google Pay payments, set the
+`stripe_country` preference, which represents the two-letter country
+code of your Stripe account:
+
 
 ```
 Spree.config do |config|
@@ -82,6 +88,7 @@ Spree.config do |config|
     'stripe_env_credentials',
     secret_key: ENV['STRIPE_SECRET_KEY'],
     publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
+    stripe_country: 'US',
     v3_elements: false,
     v3_intents: true,
     server: Rails.env.production? ? 'production' : 'test',
@@ -89,6 +96,16 @@ Spree.config do |config|
   )
 end
 ```
+
+Apple Pay and Google Pay
+-----------------------
+
+The Payment Intents API now supports also Apple Pay and Google Pay via
+the [payment request button API](https://stripe.com/docs/stripe-js/elements/payment-request-button).
+Check the Payment Intents section for setup details. Also, please
+refer to the official Stripe documentation for configuring your
+Stripe account to receive payments via Apple Pay.
+
 
 Migrating from solidus_gateway
 ------------------------------

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -5,6 +5,7 @@ module Spree
     class StripeCreditCard < Spree::PaymentMethod::CreditCard
       preference :secret_key, :string
       preference :publishable_key, :string
+      preference :stripe_country, :string
       preference :v3_elements, :boolean
       preference :v3_intents, :boolean
 
@@ -20,6 +21,10 @@ module Spree
 
       def v3_elements?
         !!preferred_v3_elements
+      end
+
+      def payment_request?
+        v3_intents? && preferred_stripe_country.present?
       end
 
       def v3_intents?

--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -1,3 +1,5 @@
+<div id="payment-request-button"></div>
+
 <%= image_tag 'credit_cards/credit_card.gif', id: 'credit-card-image' %>
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 

--- a/lib/views/frontend/spree/checkout/payment/v3/_intents.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_intents.html.erb
@@ -1,6 +1,39 @@
 <%= render 'spree/checkout/payment/v3/form_elements', payment_method: payment_method %>
 
 <script>
+  <% if payment_method.payment_request? %>
+    function setUpPaymentRequest() {
+      var paymentRequest = stripe.paymentRequest({
+        country: '<%= payment_method.preferred_stripe_country %>',
+        currency: '<%= current_order.currency.downcase %>',
+        total: {
+          label: 'Payment total for order <%= current_order.number %>',
+          amount: <%= (current_order.total * 100).to_i %>,
+        },
+        requestPayerName: true,
+        requestPayerEmail: true,
+      });
+
+      var prButton = elements.create('paymentRequestButton', {
+        paymentRequest: paymentRequest
+      });
+
+      paymentRequest.canMakePayment().then(function(result) {
+        if (result) {
+          prButton.mount('#payment-request-button');
+        } else {
+          document.getElementById('payment-request-button').style.display = 'none';
+        }
+      });
+
+      return paymentRequest;
+    };
+
+    // Using a stripe.paymentRequest is required for Apple Pay, see
+    // https://stripe.com/docs/js/payment_request/can_make_payment
+    var paymentRequest = setUpPaymentRequest();
+  <% end %>
+
   $(function() {
     var paymentMethodId = Spree.stripePaymentMethod.prop('id').split("_")[2];
     var form = Spree.stripePaymentMethod.parents('form');
@@ -9,6 +42,13 @@
     var cardType = form.find('input#cc_type');
     var authToken = $('meta[name="csrf-token"]').attr('content');
     var errorElement = $('#card-errors');
+
+    <% if payment_method.payment_request? %>
+      paymentRequest.on('paymentmethod', function(result) {
+        errorElement.text('').hide();
+        handlePayment(result);
+      });
+    <% end %>
 
     form.bind('submit', function(event) {
       if (Spree.stripePaymentMethod.is(':visible')) {
@@ -20,33 +60,38 @@
           'card',
           cardNumber
         ).then(function(result) {
-          if (result.error) {
-            showError(result.error.message);
-          } else {
-            stripeTokenHandler(result.paymentMethod);
-            fetch('/stripe/confirm_payment', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json'
-              },
-              body: JSON.stringify({
-                spree_payment_method_id: paymentMethodId,
-                stripe_payment_method_id: result.paymentMethod.id,
-                authenticity_token: authToken
-              })
-            }).then(function(result) {
-              result.json().then(function(json) {
-                handleServerResponse(json);
-              })
-            });
-          }
+          handlePayment(result);
         });
       }
     });
 
-    function handleServerResponse(response) {
+    function handlePayment(payment) {
+      if (payment.error) {
+        showError(payment.error.message);
+      } else {
+        stripeTokenHandler(payment.paymentMethod);
+        fetch('/stripe/confirm_payment', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            spree_payment_method_id: paymentMethodId,
+            stripe_payment_method_id: payment.paymentMethod.id,
+            authenticity_token: authToken
+          })
+        }).then(function(response) {
+          response.json().then(function(json) {
+            handleServerResponse(json, payment);
+          })
+        });
+      }
+    };
+
+    function handleServerResponse(response, payment) {
       if (response.error) {
           showError(response.error);
+          completePaymentRequest(payment, 'fail');
       } else if (response.requires_action) {
         stripe.handleCardAction(
           response.stripe_payment_intent_client_secret
@@ -68,7 +113,14 @@
           }
         });
       } else {
+        completePaymentRequest(payment, 'success');
         form.unbind('submit').submit();
+      }
+    }
+
+    function completePaymentRequest(payment, state) {
+      if (payment && typeof payment.complete === 'function') {
+          payment.complete(state);
       }
     }
 


### PR DESCRIPTION
Ref #22 

Payments with ApplePay and GooglePlay can be managed with Stripe only by using the [Payment Request Button API](https://stripe.com/docs/stripe-js/elements/payment-request-button) which integrates nicely with the recently added [Payment Intents](https://github.com/solidusio/solidus_stripe/pull/20) API. 

One notable concern is that this feature cannot be easily tested with automated tests, as it requires that:
* the server runs on HTTPS with a valid certificate and is accessible from the outer Internet (Stripe verifies the validity of the setup before allowing the use of the button)
* with ApplePay, a custom file with a verification code must be downloaded from the Stripe account and made available from the app to the outer Internet (again, Stripe will verify the file contents match before enabling the functionality)

Due to these hard-to-fulfill requirements for a testing environment no automated tests are provided. Please consider that a part of the functionality is based on the Payment Intents API, which is on the other hand well tested, as it does not have such strong requirements.