### PR TITLE
Remove ERB from Elements and Intents JS code

### DIFF
--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -15,6 +15,22 @@ module Spree
         'Visa' => 'visa'
       }
 
+      def stripe_config(order)
+        {
+          id: id,
+          publishable_key: preferred_publishable_key
+        }.tap do |config|
+          config.merge!(
+            payment_request: {
+              country: preferred_stripe_country,
+              currency: order.currency.downcase,
+              label: "Payment for order #{order.number}",
+              amount: (order.total * 100).to_i
+            }
+          ) if payment_request?
+        end
+      end
+
       def partial_name
         'stripe'
       end

--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -1,4 +1,4 @@
-<div id="payment-request-button"></div>
+<div id="payment-request-button" data-stripe-config="<%= payment_method.stripe_config(current_order).to_json %>"></div>
 
 <%= image_tag 'credit_cards/credit_card.gif', id: 'credit-card-image' %>
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
@@ -42,9 +42,13 @@
 <script src="https://js.stripe.com/v3/"></script>
 
 <script>
-  Spree.stripePaymentMethod = $('#payment_method_' + <%= payment_method.id %>);
+  Spree.stripePaymentMethod = {
+    config: $('[data-stripe-config').data('stripe-config')
+  }
 
-  var stripe = Stripe("<%= payment_method.preferred_publishable_key %>");
+  Spree.stripePaymentMethod.element = $('#payment_method_' + Spree.stripePaymentMethod.config.id);
+
+  var stripe = Stripe(Spree.stripePaymentMethod.config.publishable_key);
 
   var elements = stripe.elements({locale: 'en'});
 

--- a/lib/views/frontend/spree/checkout/payment/v3/_intents.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_intents.html.erb
@@ -1,17 +1,17 @@
 <%= render 'spree/checkout/payment/v3/form_elements', payment_method: payment_method %>
 
 <script>
-  <% if payment_method.payment_request? %>
-    function setUpPaymentRequest() {
+  function setUpPaymentRequest(config) {
+    if (typeof config != 'undefined') {
       var paymentRequest = stripe.paymentRequest({
-        country: '<%= payment_method.preferred_stripe_country %>',
-        currency: '<%= current_order.currency.downcase %>',
+        country: config.country,
+        currency: config.currency,
         total: {
-          label: 'Payment total for order <%= current_order.number %>',
-          amount: <%= (current_order.total * 100).to_i %>,
+          label: config.label,
+          amount: config.amount
         },
         requestPayerName: true,
-        requestPayerEmail: true,
+        requestPayerEmail: true
       });
 
       var prButton = elements.create('paymentRequestButton', {
@@ -27,31 +27,31 @@
       });
 
       return paymentRequest;
-    };
+    }
+  };
 
-    // Using a stripe.paymentRequest is required for Apple Pay, see
-    // https://stripe.com/docs/js/payment_request/can_make_payment
-    var paymentRequest = setUpPaymentRequest();
-  <% end %>
+  // Using a stripe.paymentRequest is required for Apple Pay, see
+  // https://stripe.com/docs/js/payment_request/can_make_payment
+  var paymentRequest = setUpPaymentRequest(Spree.stripePaymentMethod.config.payment_request);
 
   $(function() {
-    var paymentMethodId = Spree.stripePaymentMethod.prop('id').split("_")[2];
-    var form = Spree.stripePaymentMethod.parents('form');
+    var paymentMethodId = Spree.stripePaymentMethod.config.id;
+    var form = Spree.stripePaymentMethod.element.parents('form');
     var submitButton = form.find('input[type="submit"]');
     var errorElement = form.find('#card-errors');
     var cardType = form.find('input#cc_type');
     var authToken = $('meta[name="csrf-token"]').attr('content');
     var errorElement = $('#card-errors');
 
-    <% if payment_method.payment_request? %>
+    if (typeof paymentRequest != 'undefined') {
       paymentRequest.on('paymentmethod', function(result) {
         errorElement.text('').hide();
         handlePayment(result);
       });
-    <% end %>
+    }
 
     form.bind('submit', function(event) {
-      if (Spree.stripePaymentMethod.is(':visible')) {
+      if (Spree.stripePaymentMethod.element.is(':visible')) {
         event.preventDefault();
 
         errorElement.text('').hide();
@@ -145,10 +145,10 @@
     function stripeTokenHandler(token) {
       var baseSelector = `<input type='hidden' class='stripeToken' name='payment_source[${paymentMethodId}]`;
 
-      Spree.stripePaymentMethod.append(`${baseSelector}[gateway_payment_profile_id]' value='${token.id}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[last_digits]' value='${token.card.last4}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[month]' value='${token.card.exp_month}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[year]' value='${token.card.exp_year}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[gateway_payment_profile_id]' value='${token.id}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[last_digits]' value='${token.card.last4}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[month]' value='${token.card.exp_month}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[year]' value='${token.card.exp_year}'/>`);
       cardType.val(mapCC(token.card.brand));
     };
 

--- a/lib/views/frontend/spree/checkout/payment/v3/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_stripe.html.erb
@@ -2,7 +2,7 @@
 
 <script>
   $(function() {
-    var form = Spree.stripePaymentMethod.parents('form');
+    var form = Spree.stripePaymentMethod.element.parents('form');
     var submitButton = form.find('input[type="submit"]');
     var errorElement = form.find('#card-errors');
     var cardType = form.find('input#cc_type');
@@ -16,7 +16,7 @@
     });
 
     form.bind('submit', function(event) {
-      if (Spree.stripePaymentMethod.is(':visible')) {
+      if (Spree.stripePaymentMethod.element.is(':visible')) {
         event.preventDefault();
 
         stripe.createToken(cardNumber).then(function(result) {
@@ -34,13 +34,13 @@
     });
 
     function stripeTokenHandler(token) {
-      var paymentMethodId = Spree.stripePaymentMethod.prop('id').split("_")[2];
+      var paymentMethodId = Spree.stripePaymentMethod.config.id;
       var baseSelector = `<input type='hidden' class='stripeToken' name='payment_source[${paymentMethodId}]`;
 
-      Spree.stripePaymentMethod.append(`${baseSelector}[gateway_payment_profile_id]' value='${token.id}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[last_digits]' value='${token.card.last4}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[month]' value='${token.card.exp_month}'/>`);
-      Spree.stripePaymentMethod.append(`${baseSelector}[year]' value='${token.card.exp_year}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[gateway_payment_profile_id]' value='${token.id}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[last_digits]' value='${token.card.last4}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[month]' value='${token.card.exp_month}'/>`);
+      Spree.stripePaymentMethod.element.append(`${baseSelector}[year]' value='${token.card.exp_year}'/>`);
       cardType.val(mapCC(token.card.type));
       form[0].submit();
     };


### PR DESCRIPTION
In order to be able to move the JS business logic for Stripe payments with Intents and Elements API to an external JS file, we need to get rid of the ERB interpolation used to pass Stripe and payment config values from Ruby to the JS.