### PR TITLE
Rename v3/stripe partial as v3/elements

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_stripe.html.erb
@@ -1,5 +1,5 @@
 <% if payment_method.v3_elements? %>
-  <%= render 'spree/checkout/payment/v3/stripe', payment_method: payment_method %>
+  <%= render 'spree/checkout/payment/v3/elements', payment_method: payment_method %>
 <% elsif payment_method.v3_intents? %>
   <%= render 'spree/checkout/payment/v3/intents', payment_method: payment_method %>
 <% else %>

--- a/lib/views/frontend/spree/checkout/payment/v3/_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_elements.html.erb
@@ -1,0 +1,1 @@
+<%= render 'spree/checkout/payment/v3/form_elements', payment_method: payment_method, stripe_v3_api: 'elements' %>

--- a/lib/views/frontend/spree/checkout/payment/v3/_stripe.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_stripe.html.erb
@@ -1,1 +1,2 @@
-<%= render 'spree/checkout/payment/v3/form_elements', payment_method: payment_method, stripe_v3_api: 'elements' %>
+<% ActiveSupport::Deprecation.warn 'Partial `spree/checkout/payment/v3/_stripe.html.erb` is deprecated and will be removed soon. Please use partial `spree/checkout/payment/v3/elements`', caller(1) %>
+<%= render 'spree/checkout/payment/v3/elements', payment_method: payment_method, stripe_v3_api: 'elements' %>


### PR DESCRIPTION
The previous name was too generic, since V3 allow to use different
Stripe APIs such as Elements, Payment Intents and payment request
button.