### PR TITLE
Add hook to provide custom Stripe Elements options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ SolidusStripe.CartPageCheckout.prototype.onPrButtonMounted = function(id, result
 }
 ```
 
+Custom Stripe Elements options
+-----------------------
+
+Some custom options, like locale and fonts, can be passed when [creating a Stripe Elements instance](https://stripe.com/docs/js/elements_object/create). To customize the default options this gem provides, override the `SolidusStripe.Payment.prototype.elementsBaseOptions` method.
+
+
 Styling Stripe Elements
 -----------------------
 

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment.js
@@ -6,5 +6,11 @@ SolidusStripe.Payment = function() {
   this.authToken = $('meta[name="csrf-token"]').attr('content');
 
   this.stripe = Stripe(this.config.publishable_key);
-  this.elements = this.stripe.elements({locale: 'en'});
+  this.elements = this.stripe.elements(this.elementsBaseOptions());
+};
+
+SolidusStripe.Payment.prototype.elementsBaseOptions = function () {
+  return {
+    locale: 'en'
+  };
 };


### PR DESCRIPTION
The Stripe Elements instance is currently created with the hardcoded options `{ locale: 'en'}`. This pull request adds a hook similar to `baseStyle` for providing custom options, for example a different locale or custom fonts. The supported options are documented [here](https://stripe.com/docs/js/elements_object/create).