### PR TITLE
Fix stripe-to-solidus card type mapping

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-elements.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-elements.js
@@ -87,18 +87,20 @@ SolidusStripe.Elements.prototype.onFormSubmit = function(event) {
 
 SolidusStripe.Elements.prototype.elementsTokenHandler = function(token) {
   var mapCC = function(ccType) {
-    if (ccType === 'MasterCard') {
+    if (ccType === 'MasterCard' || ccType === 'mastercard') {
       return 'mastercard';
-    } else if (ccType === 'Visa') {
+    } else if (ccType === 'Visa' || ccType === 'visa') {
       return 'visa';
-    } else if (ccType === 'American Express') {
+    } else if (ccType === 'American Express' || ccType === 'amex') {
       return 'amex';
-    } else if (ccType === 'Discover') {
+    } else if (ccType === 'Discover' || ccType === 'discover') {
       return 'discover';
-    } else if (ccType === 'Diners Club') {
+    } else if (ccType === 'Diners Club' || ccType === 'diners') {
       return 'dinersclub';
-    } else if (ccType === 'JCB') {
+    } else if (ccType === 'JCB' || ccType === 'jcb') {
       return 'jcb';
+    } else if (ccType === 'Unionpay' || ccType === 'unionpay') {
+      return 'unionpay';
     }
   };
 


### PR DESCRIPTION
The Stripe API now seems to describe credit card brands by their code (e.g `amex`) as opposed to their display name (e.g `American Express`), which results in a blank `cc_type` for `Spree::CreditCard`. 

This pull request attempts to fix this by making the `mapCC` function  compare against both the brand code and the brand display name.