### PR TITLE
Payment Intents with card pre-authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Stripe payments.
 Using Stripe Payment Intents API
 --------------------------------
 
+⚠️ The current implementation for the Payment Intents API in the gem creates
+double charges. This happens only when the customer adds a new credit card.
+So, in order to make the issue manageable, the first charge (that is not
+recorded in Solidus but visible on Stripe dashboard) is made for the symbolic
+amount of $1.00 and labeled `Card pre-authorization for order ORDER_NUMBER`.
+This charge is not captured and is not meant to be captured. Solidus standard
+flow creates the second charge, to which corresponds a `Spree::Payment` record
+that can be managed as usual in the admin area.
+
 If you want to use the new SCA-ready Stripe Payment Intents API you need
 to change the `v3_intents` preference from the code above to true.
 

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -142,7 +142,7 @@ module Spree
         options = {}
         options[:description] = "Solidus Order ID: #{transaction_options[:order_id]}"
         options[:currency] = transaction_options[:currency]
-
+        options[:off_session] = true if v3_intents?
         if customer = creditcard.gateway_customer_profile_id
           options[:customer] = customer
         end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     context "when using a valid 3D Secure card" do
-      let(:card_number) { "4000 0027 6000 3184" }
+      let(:card_number) { "4000 0025 0000 3155" }
 
       it "successfully completes the checkout" do
         within_frame find('#card_number iframe') do
@@ -370,7 +370,7 @@ RSpec.describe "Stripe checkout", type: :feature do
 
     it "can re-use saved cards" do
       within_frame find('#card_number iframe') do
-        "4000 0027 6000 3184".split('').each { |n| find_field('cardnumber').native.send_keys(n) }
+        "4000 0025 0000 3155".split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
       within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
       within_frame(find '#card_expiry iframe') do

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe "Stripe checkout", type: :feature do
         click_button "Save and Continue"
 
         within_3d_secure_modal do
-          expect(page).to have_content '$19.99 using 3D Secure'
+          expect(page).to have_content '$1.00 using 3D Secure'
 
           click_button 'Complete authentication'
         end


### PR DESCRIPTION
At the moment payments done with Payment Intents end up in a double charge for the customer. 

A first charge is created instantly when the customer authorizes their card, and a second one is created later after order confirmation. This issue is not of easy solution, as the first charge is always required for Payment Intents, and the second one is created automatically by Solidus flow.
Also, the first charge happens outside of Solidus' current processes, so there's no record of it in on the DB.

A possible temporary workaround for this issue is to introduce the concept of card pre-authorization: the first charge, now limited to only 1$ is not captured anymore, and have an appropriate description so, even when customers receive notifications for uncaptured transactions from their bank, they will understand this is not going to be actually captured.