### PR TITLE
Create a single charge when using Stripe Payment Intents

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
@@ -69,6 +69,7 @@ SolidusStripe.PaymentIntents.prototype.onIntentsPayment = function(payment) {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
+        form_data: this.form.serialize(),
         spree_payment_method_id: this.config.id,
         stripe_payment_method_id: payment.paymentMethod.id,
         authenticity_token: this.authToken

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
@@ -100,6 +100,7 @@
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            form_data: this.form.serialize(),
             spree_payment_method_id: this.config.id,
             stripe_payment_intent_id: result.paymentIntent.id,
             authenticity_token: this.authToken

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -6,27 +6,19 @@ module SolidusStripe
 
     def confirm
       begin
-        if params[:stripe_payment_method_id].present?
-          intent = stripe.create_intent(
-            (current_order.total * 100).to_i,
-            params[:stripe_payment_method_id],
-            description: "Solidus Order ID: #{current_order.number} (pending)",
-            currency: current_order.currency,
-            confirmation_method: 'manual',
-            capture_method: 'manual',
-            confirm: true,
-            setup_future_usage: 'off_session',
-            metadata: { order_id: current_order.id }
-          )
-        elsif params[:stripe_payment_intent_id].present?
-          intent = stripe.confirm_intent(params[:stripe_payment_intent_id], nil)
+        @intent = begin
+          if params[:stripe_payment_method_id].present?
+            create_intent
+          elsif params[:stripe_payment_intent_id].present?
+            stripe.confirm_intent(params[:stripe_payment_intent_id], nil)
+          end
         end
       rescue Stripe::CardError => e
         render json: { error: e.message }, status: 500
         return
       end
 
-      generate_payment_response(intent)
+      generate_payment_response
     end
 
     private
@@ -35,21 +27,35 @@ module SolidusStripe
       @stripe ||= Spree::PaymentMethod::StripeCreditCard.find(params[:spree_payment_method_id])
     end
 
-    def generate_payment_response(intent)
-      response = intent.params
+    def generate_payment_response
+      response = @intent.params
       # Note that if your API version is before 2019-02-11, 'requires_action'
       # appears as 'requires_source_action'.
       if %w[requires_source_action requires_action].include?(response['status']) && response['next_action']['type'] == 'use_stripe_sdk'
-          render json: {
-            requires_action: true,
-            stripe_payment_intent_client_secret: response['client_secret']
-          }
+        render json: {
+          requires_action: true,
+          stripe_payment_intent_client_secret: response['client_secret']
+        }
       elsif response['status'] == 'requires_capture'
-        SolidusStripe::CreateIntentsOrderService.new(intent, stripe, self).call
+        SolidusStripe::CreateIntentsOrderService.new(@intent, stripe, self).call
         render json: { success: true }
       else
         render json: { error: response['error']['message'] }, status: 500
       end
+    end
+
+    def create_intent
+      stripe.create_intent(
+        (current_order.total * 100).to_i,
+        params[:stripe_payment_method_id],
+        description: "Solidus Order ID: #{current_order.number} (pending)",
+        currency: current_order.currency,
+        confirmation_method: 'manual',
+        capture_method: 'manual',
+        confirm: true,
+        setup_future_usage: 'off_session',
+        metadata: { order_id: current_order.id }
+      )
     end
   end
 end

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -45,6 +45,7 @@ module SolidusStripe
             stripe_payment_intent_client_secret: response['client_secret']
           }
       elsif response['status'] == 'requires_capture'
+        SolidusStripe::CreateIntentsOrderService.new(intent, stripe, self).call
         render json: { success: true }
       else
         render json: { error: response['error']['message'] }, status: 500

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -10,10 +10,12 @@ module SolidusStripe
           intent = stripe.create_intent(
             (current_order.total * 100).to_i,
             params[:stripe_payment_method_id],
+            description: "Solidus Order ID: #{current_order.number} (pending)",
             currency: current_order.currency,
             confirmation_method: 'manual',
+            capture_method: 'manual',
             confirm: true,
-            setup_future_usage: 'on_session',
+            setup_future_usage: 'off_session',
             metadata: { order_id: current_order.id }
           )
         elsif params[:stripe_payment_intent_id].present?
@@ -42,7 +44,7 @@ module SolidusStripe
             requires_action: true,
             stripe_payment_intent_client_secret: response['client_secret']
           }
-      elsif response['status'] == 'succeeded'
+      elsif response['status'] == 'requires_capture'
         render json: { success: true }
       else
         render json: { error: response['error']['message'] }, status: 500

--- a/app/decorators/models/spree/order_update_attributes_decorator.rb
+++ b/app/decorators/models/spree/order_update_attributes_decorator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Spree
+  module OrderUpdateAttributesDecorator
+    def assign_payments_attributes
+      return if payments_attributes.empty?
+      return if adding_new_stripe_payment_intents_card?
+
+      stripe_intents_pending_payments.each(&:void_transaction!)
+
+      super
+    end
+
+    private
+
+    def adding_new_stripe_payment_intents_card?
+      paying_with_stripe_intents? && stripe_intents_pending_payments.any?
+    end
+
+    def stripe_intents_pending_payments
+      @stripe_intents_pending_payments ||= order.payments.valid.select do |payment|
+        payment_method = payment.payment_method
+        payment.pending? && stripe_intents?(payment_method)
+      end
+    end
+
+    def paying_with_stripe_intents?
+      if id = payments_attributes.first&.dig(:payment_method_id)
+        stripe_intents?(Spree::PaymentMethod.find(id))
+      end
+    end
+
+    def stripe_intents?(payment_method)
+      payment_method.respond_to?(:v3_intents?) && payment_method.v3_intents?
+    end
+
+    ::Spree::OrderUpdateAttributes.prepend(self)
+  end
+end

--- a/app/decorators/models/spree/payment_decorator.rb
+++ b/app/decorators/models/spree/payment_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module PaymentDecorator
+    def gateway_order_identifier
+      gateway_order_id
+    end
+
+    ::Spree::Payment.prepend(self)
+  end
+end

--- a/app/models/solidus_stripe/create_intents_order_service.rb
+++ b/app/models/solidus_stripe/create_intents_order_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class CreateIntentsOrderService
+    attr_reader :intent, :stripe, :controller
+
+    delegate :request, :current_order, :params, to: :controller
+
+    def initialize(intent, stripe, controller)
+      @intent, @stripe, @controller = intent, stripe, controller
+    end
+
+    def call
+      payment = create_payment
+      description = "Solidus Order ID: #{payment.gateway_order_identifier}"
+      stripe.update_intent(nil, response['id'], nil, description: description)
+    end
+
+    private
+
+    def create_payment
+      Spree::OrderUpdateAttributes.new(
+        current_order,
+        payment_params,
+        request_env: request.headers.env
+      ).apply
+
+      Spree::Payment.find_by(response_code: response['id']).tap do |payment|
+        payment.update!(state: :pending)
+      end
+    end
+
+    def payment_params
+      card = response['charges']['data'][0]['payment_method_details']['card']
+      address_attributes = form_data['payment_source'][stripe.id.to_s]['address_attributes']
+
+      {
+        payments_attributes: [{
+          payment_method_id: stripe.id,
+          amount: current_order.total,
+          response_code: response['id'],
+          source_attributes: {
+            month: card['exp_month'],
+            year: card['exp_year'],
+            cc_type: card['brand'],
+            gateway_payment_profile_id: response['payment_method'],
+            last_digits: card['last4'],
+            name: current_order.bill_address.full_name,
+            address_attributes: address_attributes
+          }
+        }]
+      }
+    end
+
+    def response
+      intent.params
+    end
+
+    def form_data
+      Rack::Utils.parse_nested_query(params[:form_data])
+    end
+  end
+end

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -15,6 +15,8 @@ module Spree
         'Visa' => 'visa'
       }
 
+      delegate :create_intent, :update_intent, :confirm_intent, to: :gateway
+
       def stripe_config(order)
         {
           id: id,
@@ -57,14 +59,6 @@ module Spree
 
       def payment_profiles_supported?
         true
-      end
-
-      def create_intent(*args)
-        gateway.create_intent(*args)
-      end
-
-      def confirm_intent(*args)
-        gateway.confirm_intent(*args)
       end
 
       def purchase(money, creditcard, transaction_options)

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -142,6 +142,7 @@ module Spree
         options = {}
         options[:description] = "Solidus Order ID: #{transaction_options[:order_id]}"
         options[:currency] = transaction_options[:currency]
+        options[:off_session] = true if v3_intents?
 
         if customer = creditcard.gateway_customer_profile_id
           options[:customer] = customer

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     context "when using a valid 3D Secure card" do
-      let(:card_number) { "4000 0027 6000 3184" }
+      let(:card_number) { "4000 0025 0000 3155" }
 
       it "successfully completes the checkout" do
         within_frame find('#card_number iframe') do
@@ -370,7 +370,7 @@ RSpec.describe "Stripe checkout", type: :feature do
 
     it "can re-use saved cards" do
       within_frame find('#card_number iframe') do
-        "4000 0027 6000 3184".split('').each { |n| find_field('cardnumber').native.send_keys(n) }
+        "4000 0025 0000 3155".split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
       within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
       within_frame(find '#card_expiry iframe') do


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus_stripe/issues/44, plus other minor issues found while working on that main problem.

When using the Payment Intents API, we need to create a single charge. In order to achieve the goal, we now create a Solidus payment as soon as the Payment Intent is authorized from Stripe (while the customer is still on the payment page). Later, we skip the creation of the second payment during Solidus default flow after the order has been confirmed. 

The first payment will be created `uncaptured` instead of `authorized` (already captured) as the customer may decide to not complete their purchase. 

When the customer enters multiple credit cards during the same checkout process or changes the payment method from a freshly entered credit card to something else (ie. check) we also need to properly invalidate (void) stale Payment Intents charges and their payment records in Solidus.

This PR also fixes an issue with 3D-Secure card reusability. before this fix, orders finalized by reusing an already authorized 3DS card would end up in creating payments that cannot be properly captured. 

Some integration tests were added in order to improve edge cases coverage, including checks on the backend that verify payments are created with the proper state and their capturability, when appropriate.
