### PR TITLE
Replace deprecated route `/stripe/confirm_payment`

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
@@ -21,7 +21,7 @@ SolidusStripe.PaymentIntents.prototype.onPrPayment = function(payment) {
     var that = this;
 
     this.elementsTokenHandler(payment.paymentMethod);
-    fetch('/stripe/confirm_payment', {
+    fetch('/stripe/confirm_intents', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
This is a leftover, that route was superseded by `/stripe/confirm_intents`.
