### PR TITLE
Relax solidus_support dependency

### DIFF
--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusStripe
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   s.add_dependency 'solidus_core', ['>= 2.3', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '~> 0.5'
   # ActiveMerchant v1.58 through v1.59 introduced a breaking change
   # to the stripe gateway.
   #


### PR DESCRIPTION
It allows to use the latest version of Solidus Support and also removes a deprecated module inclusion.