### PR TITLE
Fix for 3D-Secure payments on cart page checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ Spree.config do |config|
 end
 ```
 
+When using the Payment Intents API, be aware that the charge flow will be a bit
+different than when using the old V2 API or Elements. It's advisable that all
+Payment Intents charges are captured only by using the Solidus backend, as it is
+the final source of truth in regards of Solidus orders payments.
+
+A Payment Intent is created as soon as the customer enters their credit card
+data. A tentative charge will be created on Stripe, easily recognizable by its
+description: `Solidus Order ID: R987654321 (pending)`. As soon as the credit
+card is confirmed (ie. when the customer passes the 3DSecure authorization, when
+required) then the charge description gets updated to include the Solidus payment
+number: `Solidus Order ID: R987654321-Z4VYUDB3`.
+
+These charges are created `uncaptured` and will need to be captured in Solidus
+backend later, after the customer confirms the order. If the customer never
+completes the checkout, that charge must remain uncaptured. If the customer
+decides to change their payment method after creating a Payment Request, then
+that Payment Request charge will be canceled.
+
+
 Apple Pay and Google Pay
 -----------------------
 
@@ -210,13 +229,13 @@ You can also style your element containers directly by using CSS rules like this
 
 ### Customizing individual input fields
 
-If you want to customize individual input fields, you can override these methods 
+If you want to customize individual input fields, you can override these methods
 
 * `SolidusStripe.Elements.prototype.cardNumberElementOptions`
 * `SolidusStripe.Elements.prototype.cardExpiryElementOptions`
 * `SolidusStripe.Elements.prototype.cardCvcElementOptions`
 
-and return a valid [options object](https://stripe.com/docs/js/elements_object/create_element?type=cardNumber) for the corresponding field type. For example, this code sets a custom placeholder and enables the credit card icon for the card number field 
+and return a valid [options object](https://stripe.com/docs/js/elements_object/create_element?type=cardNumber) for the corresponding field type. For example, this code sets a custom placeholder and enables the credit card icon for the card number field
 
 ```js
 SolidusStripe.Elements.prototype.cardNumberElementOptions = function () {
@@ -230,7 +249,7 @@ SolidusStripe.Elements.prototype.cardNumberElementOptions = function () {
 
 ### Passing options to the Stripe Elements instance
 
-By overriding the `SolidusStripe.Payment.prototype.elementsBaseOptions` method and returning a [valid options object](https://stripe.com/docs/js/elements_object/create), you can pass custom options to the Stripe Elements instance. 
+By overriding the `SolidusStripe.Payment.prototype.elementsBaseOptions` method and returning a [valid options object](https://stripe.com/docs/js/elements_object/create), you can pass custom options to the Stripe Elements instance.
 
 Note that in order to use web fonts with Stripe Elements, you must specify the fonts when creating the Stripe Elements instance. Here's an example specifying a custom web font and locale:
 

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -72,7 +72,7 @@ SolidusStripe.CartPageCheckout.prototype.createIntent = function(result, payment
     if (payment.error) {
       this.showError(payment.error.message);
     } else {
-      fetch('/stripe/confirm_intents', {
+      fetch('/stripe/create_intent', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -16,7 +16,9 @@ SolidusStripe.CartPageCheckout.prototype.init = function() {
 };
 
 SolidusStripe.CartPageCheckout.prototype.showError = function(error) {
-  this.errorElement.text(error).show();
+  var message = error.message || error;
+
+  this.errorElement.text(message).show();
 };
 
 SolidusStripe.CartPageCheckout.prototype.submitPayment = function(payment) {

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -42,7 +42,7 @@ SolidusStripe.CartPageCheckout.prototype.submitPayment = function(payment) {
 };
 
 SolidusStripe.CartPageCheckout.prototype.onPrPayment = function(payment) {
-  var handleServerResponse = this.handleServerResponse.bind(this);
+  var createIntent = this.createIntent.bind(this);
 
   fetch('/stripe/update_order', {
     method: 'POST',
@@ -56,9 +56,39 @@ SolidusStripe.CartPageCheckout.prototype.onPrPayment = function(payment) {
     })
   }).then(function(response) {
     response.json().then(function(json) {
-      handleServerResponse(json, payment);
+      createIntent(json, payment);
     })
   });
+};
+
+SolidusStripe.CartPageCheckout.prototype.createIntent = function(result, payment) {
+  var handleServerResponse = this.handleServerResponse.bind(this);
+
+  if (result.error) {
+    this.completePaymentRequest(payment, 'fail');
+    this.showError(result.error);
+  } else {
+    if (payment.error) {
+      this.showError(payment.error.message);
+    } else {
+      fetch('/stripe/confirm_intents', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          form_data: payment.shippingAddress,
+          spree_payment_method_id: this.config.id,
+          stripe_payment_method_id: payment.paymentMethod.id,
+          authenticity_token: this.authToken
+        })
+      }).then(function(response) {
+        response.json().then(function(result) {
+          handleServerResponse(result, payment)
+        })
+      });
+    }
+  }
 };
 
 SolidusStripe.CartPageCheckout.prototype.onPrButtonMounted = function(buttonId, success) {

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -41,22 +41,22 @@ SolidusStripe.CartPageCheckout.prototype.submitPayment = function(payment) {
   });
 };
 
-SolidusStripe.CartPageCheckout.prototype.onPrPayment = function(result) {
+SolidusStripe.CartPageCheckout.prototype.onPrPayment = function(payment) {
   var handleServerResponse = this.handleServerResponse.bind(this);
 
   fetch('/stripe/update_order', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      shipping_address: result.shippingAddress,
-      shipping_option: result.shippingOption,
-      email: result.payerEmail,
-      name: result.payerName,
+      shipping_address: payment.shippingAddress,
+      shipping_option: payment.shippingOption,
+      email: payment.payerEmail,
+      name: payment.payerName,
       authenticity_token: this.authToken
     })
   }).then(function(response) {
     response.json().then(function(json) {
-      handleServerResponse(json, result);
+      handleServerResponse(json, payment);
     })
   });
 };

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -23,6 +23,7 @@ SolidusStripe.CartPageCheckout.prototype.showError = function(error) {
 
 SolidusStripe.CartPageCheckout.prototype.submitPayment = function(payment) {
   var showError = this.showError.bind(this);
+  var prTokenHandler = this.prTokenHandler.bind(this);
 
   $.ajax({
     url: $('[data-submit-url]').data('submit-url'),
@@ -31,7 +32,7 @@ SolidusStripe.CartPageCheckout.prototype.submitPayment = function(payment) {
     },
     type: 'PATCH',
     contentType: 'application/json',
-    data: JSON.stringify(this.prTokenHandler(payment.paymentMethod)),
+    data: JSON.stringify(prTokenHandler(payment.paymentMethod)),
     success: function() {
       window.location = $('[data-complete-url]').data('complete-url');
     },

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-intents.js
@@ -21,7 +21,7 @@ SolidusStripe.PaymentIntents.prototype.onPrPayment = function(payment) {
     var that = this;
 
     this.elementsTokenHandler(payment.paymentMethod);
-    fetch('/stripe/confirm_intents', {
+    fetch('/stripe/create_intent', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -64,7 +64,7 @@ SolidusStripe.PaymentIntents.prototype.onIntentsPayment = function(payment) {
     var that = this;
 
     this.elementsTokenHandler(payment.paymentMethod);
-    fetch('/stripe/confirm_intents', {
+    fetch('/stripe/create_intent', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
@@ -114,6 +114,10 @@
     completePaymentRequest: function(payment, state) {
       if (payment && typeof payment.complete === 'function') {
         payment.complete(state);
+        if (state === 'fail') {
+          // restart the button (required in order to force address choice)
+          new SolidusStripe.CartPageCheckout().init();
+        }
       }
     }
   };

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
@@ -111,6 +111,31 @@
       }
     },
 
+    completePayment: function(payment, stripePaymentIntentId) {
+      var onCreateBackendPayment = function (response) {
+        if (response.error) {
+          this.completePaymentRequest(payment, 'fail');
+          this.showError(response.error);
+        } else {
+          this.completePaymentRequest(payment, 'success');
+          this.submitPayment(payment);
+        }
+      }.bind(this);
+
+      fetch('/stripe/create_payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          form_data: this.form ? this.form.serialize() : payment.shippingAddress,
+          spree_payment_method_id: this.config.id,
+          stripe_payment_intent_id: stripePaymentIntentId,
+          authenticity_token: this.authToken
+        })
+      }).then(function(solidusPaymentResponse) {
+        return solidusPaymentResponse.json();
+      }).then(onCreateBackendPayment)
+    },
+
     completePaymentRequest: function(payment, state) {
       if (payment && typeof payment.complete === 'function') {
         payment.complete(state);

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -37,7 +37,7 @@ module SolidusStripe
           stripe_payment_intent_client_secret: response['client_secret']
         }
       elsif response['status'] == 'requires_capture'
-        SolidusStripe::CreateIntentsOrderService.new(@intent, stripe, self).call
+        SolidusStripe::CreateIntentsPaymentService.new(@intent, stripe, self).call
         render json: { success: true }
       else
         render json: { error: response['error']['message'] }, status: 500

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -4,7 +4,7 @@ module SolidusStripe
   class IntentsController < Spree::BaseController
     include Spree::Core::ControllerHelpers::Order
 
-    def confirm
+    def create_intent
       begin
         @intent = create_payment_intent
       rescue Stripe::CardError => e

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -6,13 +6,7 @@ module SolidusStripe
 
     def confirm
       begin
-        @intent = begin
-          if params[:stripe_payment_method_id].present?
-            create_intent
-          elsif params[:stripe_payment_intent_id].present?
-            stripe.confirm_intent(params[:stripe_payment_intent_id], nil)
-          end
-        end
+        @intent = create_payment_intent
       rescue Stripe::CardError => e
         render json: { error: e.message }, status: 500
         return
@@ -49,13 +43,13 @@ module SolidusStripe
       end
     end
 
-    def create_intent
+    def create_payment_intent
       stripe.create_intent(
         (current_order.total * 100).to_i,
         params[:stripe_payment_method_id],
         description: "Solidus Order ID: #{current_order.number} (pending)",
         currency: current_order.currency,
-        confirmation_method: 'manual',
+        confirmation_method: 'automatic',
         capture_method: 'manual',
         confirm: true,
         setup_future_usage: 'off_session',

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -21,6 +21,11 @@ module SolidusStripe
       generate_payment_response
     end
 
+    def create_payment
+      SolidusStripe::CreateIntentsPaymentService.new(params[:stripe_payment_intent_id], stripe, self).call
+      render json: { success: true }
+    end
+
     private
 
     def stripe

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -16,8 +16,17 @@ module SolidusStripe
     end
 
     def create_payment
-      SolidusStripe::CreateIntentsPaymentService.new(params[:stripe_payment_intent_id], stripe, self).call
-      render json: { success: true }
+      create_payment_service = SolidusStripe::CreateIntentsPaymentService.new(
+        params[:stripe_payment_intent_id],
+        stripe,
+        self
+      )
+
+      if create_payment_service.call
+        render json: { success: true }
+      else
+        render json: { error: "Could not create payment" }, status: 500
+      end
     end
 
     private

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -36,8 +36,11 @@ module SolidusStripe
           stripe_payment_intent_client_secret: response['client_secret']
         }
       elsif response['status'] == 'requires_capture'
-        SolidusStripe::CreateIntentsPaymentService.new(@intent, stripe, self).call
-        render json: { success: true }
+        render json: {
+          success: true,
+          requires_capture: true,
+          stripe_payment_intent_id: response['id']
+        }
       else
         render json: { error: response['error']['message'] }, status: 500
       end

--- a/app/models/solidus_stripe/address_from_params_service.rb
+++ b/app/models/solidus_stripe/address_from_params_service.rb
@@ -4,7 +4,7 @@ module SolidusStripe
   class AddressFromParamsService
     attr_reader :address_params, :user
 
-    def initialize(address_params, user)
+    def initialize(address_params, user = nil)
       @address_params, @user = address_params, user
     end
 

--- a/app/models/solidus_stripe/create_intents_payment_service.rb
+++ b/app/models/solidus_stripe/create_intents_payment_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusStripe
-  class CreateIntentsOrderService
+  class CreateIntentsPaymentService
     attr_reader :intent, :stripe, :controller
 
     delegate :request, :current_order, :params, to: :controller

--- a/app/models/solidus_stripe/create_intents_payment_service.rb
+++ b/app/models/solidus_stripe/create_intents_payment_service.rb
@@ -17,6 +17,7 @@ module SolidusStripe
         stripe.update_intent(nil, intent_id, nil, description: description)
         true
       else
+        invalidate_current_payment_intent
         false
       end
     end
@@ -25,6 +26,10 @@ module SolidusStripe
 
     def intent
       @intent ||= stripe.show_intent(intent_id, {})
+    end
+
+    def invalidate_current_payment_intent
+      stripe.cancel(intent_id)
     end
 
     def invalidate_previous_payment_intents_payments

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -15,7 +15,7 @@ module Spree
         'Visa' => 'visa'
       }
 
-      delegate :create_intent, :update_intent, :confirm_intent, to: :gateway
+      delegate :create_intent, :update_intent, :confirm_intent, :show_intent, to: :gateway
 
       def stripe_config(order)
         {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Spree::Core::Engine.routes.draw do
   post '/stripe/confirm_payment', to: 'stripe#confirm_payment'
 
   # payment intents routes:
-  post '/stripe/confirm_intents', to: '/solidus_stripe/intents#confirm'
+  post '/stripe/create_intent', to: '/solidus_stripe/intents#create_intent'
   post '/stripe/create_payment', to: '/solidus_stripe/intents#create_payment'
 
   # payment request routes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Spree::Core::Engine.routes.draw do
 
   # payment intents routes:
   post '/stripe/confirm_intents', to: '/solidus_stripe/intents#confirm'
+  post '/stripe/create_payment', to: '/solidus_stripe/intents#create_payment'
 
   # payment request routes:
   post '/stripe/shipping_rates', to: '/solidus_stripe/payment_request#shipping_rates'

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -487,8 +487,8 @@ RSpec.describe "Stripe checkout", type: :feature do
   end
 
   def within_3d_secure_modal
-    within_frame "__privateStripeFrame10" do
-      within_frame "challengeFrame" do
+    within_frame "__privateStripeFrame11" do
+      within_frame "__stripeJSChallengeFrame" do
         yield
       end
     end

--- a/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusStripe::CreateIntentsPaymentService do
+  let(:service) { described_class.new(intent_id, stripe, controller) }
+
+  let(:stripe) {
+    Spree::PaymentMethod::StripeCreditCard.create!(
+      name: "Stripe",
+      preferred_secret_key: "sk_test_VCZnDv3GLU15TRvn8i2EsaAN",
+      preferred_publishable_key: "pk_test_Cuf0PNtiAkkMpTVC2gwYDMIg",
+      preferred_v3_elements: false,
+      preferred_v3_intents: true
+    )
+  }
+
+  let(:order) { create :order, state: :payment, total: 19.99 }
+
+  let(:intent_id) { "pi_123123ABC" }
+  let(:controller) { double(current_order: order.reload, params: params, request: spy) }
+
+  let(:params) do
+    {
+      spree_payment_method_id: stripe.id,
+      stripe_payment_intent_id: intent_id,
+      form_data: {
+        addressLine: ["31 Cotton Rd"],
+        city: "San Diego",
+        country: "US",
+        phone: "+188836412312",
+        postalCode: "12345",
+        recipient: "James Edwards",
+        region: "CA"
+      }
+    }
+  end
+
+  let(:intent) do
+    double(params: {
+      "id" => intent_id,
+      "charges" => {
+        "data" => [{
+          "payment_method_details" => {
+            "card" => {
+              "brand" => "visa",
+              "exp_month" => 1,
+              "exp_year" => 2022,
+              "last4" => "4242"
+            },
+          }
+        }]
+      }
+    })
+  end
+
+  describe '#call' do
+    subject { service.call }
+
+    before do
+      allow(stripe).to receive(:show_intent) { intent }
+      allow_any_instance_of(Spree::CreditCard).to receive(:require_card_numbers?) { false }
+      allow_any_instance_of(Spree::PaymentMethod::StripeCreditCard).to receive(:create_profile) { true }
+    end
+
+    it { expect(subject).to be true }
+
+    it "creates a new pending payment" do
+      expect { subject }.to change { order.payments.count }
+      expect(order.payments.last.reload).to be_pending
+    end
+
+    context "when for any reason the payment could not be created" do
+      before { params[:form_data].delete(:city) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "when there are previous pending payments" do
+      let!(:payment) do
+        create(:payment, order: order).tap do |payment|
+          payment.update!(state: :pending)
+        end
+      end
+
+      before do
+        response = double(success?: true, authorization: payment.response_code)
+        allow_any_instance_of(Spree::PaymentMethod::StripeCreditCard).to receive(:void) { response }
+      end
+
+      context "when one of them is a Payment Intent" do
+        before do
+          payment.update!(payment_method: stripe)
+          payment.source.update!(payment_method: stripe)
+        end
+
+        it "invalidates it" do
+          expect { subject }.to change { payment.reload.state }.to 'void'
+        end
+      end
+
+      context "when none is a Payment Intent" do
+        it "does not invalidate them" do
+          expect { subject }.not_to change { payment.reload.state }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The cart page checkout did not work properly when paying with a 3D-Secure credit card. 

This PR fixes the cart checkout payment flow by making sure that a proper payment intent is created and authorized. This requires also to manually create the corresponding Solidus payment
record, as it happens already in the regular Payment Intents flow. 

The payment intent is now confirmed automatically (ie. in the browser) so there's no more need to confirm it via Ruby in the Intents controller. According to Stripe customer support, this change is required in order to be able to properly manage the 3D-Secure iframe popup after the payment request data gathering process is completed in the browser. 

All these changes resulted in a significant rework of the JS code for the cart checkout flow and the shared code between the cart checkout and the regular Payment Intent  flow.