### PR TITLE
Fix order cancel with Payment Intents captured payment

### DIFF
--- a/app/decorators/models/spree/refund_decorator.rb
+++ b/app/decorators/models/spree/refund_decorator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree
+  module RefundDecorator
+    attr_reader :response
+
+    Spree::Refund.prepend(self)
+  end
+end

--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -81,6 +81,21 @@ module Spree
         gateway.void(response_code, {})
       end
 
+      def payment_intents_refund_reason
+        Spree::RefundReason.where(name: Spree::Payment::Cancellation::DEFAULT_REASON).first_or_create
+      end
+
+      def try_void(payment)
+        if v3_intents? && payment.completed?
+          payment.refunds.create!(
+            amount: payment.credit_allowed,
+            reason: payment_intents_refund_reason
+          ).response
+        else
+          payment.void_transaction!
+        end
+      end
+
       def cancel(response_code)
         gateway.void(response_code, {})
       end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -400,8 +400,9 @@ RSpec.describe "Stripe checkout", type: :feature do
         click_button "Place Order"
         expect(page).to have_content("Your order has been processed successfully")
 
-        # Capture in backend
         Spree::Order.complete.each do |order|
+          # Capture in backend
+
           visit spree.admin_path
 
           expect(page).to have_selector("#listing_orders tbody tr", count: 2)
@@ -413,6 +414,21 @@ RSpec.describe "Stripe checkout", type: :feature do
 
           expect(page).to have_content "Payment Updated"
           expect(find("table#payments")).to have_content "Completed"
+
+          # Order cancel, after capture
+          click_link "Cart"
+
+          within "#sidebar" do
+            expect(page).to have_content "Completed"
+          end
+
+          find('input[value="Cancel"]').click
+
+          expect(page).to have_content "Order canceled"
+
+          within "#sidebar" do
+            expect(page).to have_content "Canceled"
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus_stripe/issues/56

This PR adds the `Spree::PaymentMethod::StripeCreditCard#try_void` method that is now called when an order is canceled in the admin area (Solidus used to call the now deprecated method `Spree::PaymentMethod#cancel`).

If we're dealing with a Payment Intents payment, and the payment is already captured, Stripe will not allow canceling it, we can only refund it. 

Also, a custom refund reason record is added via migration, in order to be able to clearly determine those payments that were refunded because there was no alternative.
