### PR TITLE
Remove Stripe::CardError leftover

### DIFF
--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -5,13 +5,7 @@ module SolidusStripe
     include Spree::Core::ControllerHelpers::Order
 
     def create_intent
-      begin
-        @intent = create_payment_intent
-      rescue Stripe::CardError => e
-        render json: { error: e.message }, status: 500
-        return
-      end
-
+      @intent = create_payment_intent
       generate_payment_response
     end
 


### PR DESCRIPTION
Fixes https://github.com/solidusio/solidus_stripe/issues/55

The error `Stripe::CardError` is defined inside the official Stripe gem, which was used in the beginnig for developing a early version of the payment intents flow. We later switched to Active Merchant in order to reduce the number of dependencies, as the latter was already in use on this extension and since version 1.101 is capable of handing Stripe Payment Intents as well.

The begin/rescue block was completely removed since there's no known error that can be generated during the creation of the Payment Intent that makes sense to rescue. This is also due to the fact that Active Merchant already tries to manage many possible errors at a lower level.

The fact that this leftover remained unnoticed for so long is proof that no error is usually generated in that part of the code, @rainerdema was able to exercise the `rescue` block while writing tests, where `current_order` was left to `nil` by mistake.