### PR TITLE
Add stripe name to payment form fields id

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -1,7 +1,7 @@
 SolidusStripe.CartPageCheckout = function() {
   SolidusStripe.Payment.call(this);
 
-  this.errorElement = $('#card-errors');
+  this.errorElement = $('#stripe_card_errors');
 };
 
 SolidusStripe.CartPageCheckout.prototype = Object.create(SolidusStripe.Payment.prototype);

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-elements.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-elements.js
@@ -2,7 +2,7 @@ SolidusStripe.Elements = function() {
   SolidusStripe.Payment.call(this);
 
   this.form = this.element.parents('form');
-  this.errorElement = this.form.find('#card-errors');
+  this.errorElement = this.form.find('#stripe_card_errors');
   this.submitButton = this.form.find('input[type="submit"]');
 };
 
@@ -19,13 +19,13 @@ SolidusStripe.Elements.prototype.init = function() {
 
 SolidusStripe.Elements.prototype.initElements = function() {
   var cardExpiry = this.elements.create('cardExpiry', this.cardExpiryElementOptions());
-  cardExpiry.mount('#card_expiry');
+  cardExpiry.mount('#stripe_card_expiry');
 
   var cardCvc = this.elements.create('cardCvc', this.cardCvcElementOptions());
-  cardCvc.mount('#card_cvc');
+  cardCvc.mount('#stripe_card_cvc');
 
   this.cardNumber = this.elements.create('cardNumber', this.cardNumberElementOptions());
-  this.cardNumber.mount('#card_number');
+  this.cardNumber.mount('#stripe_card_number');
 
   this.form.bind('submit', this.onFormSubmit.bind(this));
 

--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -9,8 +9,8 @@
 </div>
 
 <div class="field field-required" data-hook="card_number">
-  <%= label_tag "card_number", t('spree.card_number') %>
-  <div id="card_number"></div>
+  <%= label_tag "stripe_card_number", t('spree.card_number') %>
+  <div id="stripe_card_number"></div>
   <span id="card_type" style="display:none;">
     ( <span id="looks_like" ><%= t('spree.card_type_is') %> <span id="type"></span></span>
       <span id="unrecognized"><%= t('spree.unrecognized_card_type') %></span>
@@ -19,17 +19,17 @@
 </div>
 
 <div class="field field-required" data-hook="card_expiration">
-  <%= label_tag "card_expiry", t('spree.expiration') %>
-  <div id="card_expiry"></div>
+  <%= label_tag "stripe_card_expiry", t('spree.expiration') %>
+  <div id="stripe_card_expiry"></div>
 </div>
 
 <div class="field field-required" data-hook="card_code">
-  <%= label_tag "card_cvc", t('spree.card_code') %>
-  <div id="card_cvc"></div>
+  <%= label_tag "stripe_card_cvc", t('spree.card_code') %>
+  <div id="stripe_card_cvc"></div>
   <%= link_to "(#{t('spree.what_is_this')})", spree.cvv_path, target: '_blank', "data-hook" => "cvv_link", id: "cvv_link" %>
 </div>
 
-<div id="card-errors" class='errorExplanation' role="alert" style="display: none"></div>
+<div id="stripe_card_errors" class='errorExplanation' role="alert" style="display: none"></div>
 
 <% if @order.bill_address %>
   <%= fields_for "#{param_prefix}[address_attributes]", @order.bill_address do |f| %>

--- a/lib/views/frontend/spree/orders/_stripe_payment_request_button.html.erb
+++ b/lib/views/frontend/spree/orders/_stripe_payment_request_button.html.erb
@@ -8,7 +8,7 @@
       class="payment-request-button">
     </div>
 
-    <div id="card-errors" class='errorExplanation' role="alert" style="display: none">
+    <div id="stripe_card_errors" class='errorExplanation' role="alert" style="display: none">
     </div>
   </div>
 <% end %>

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe "Stripe checkout", type: :feature do
 
   shared_examples "Stripe Elements invalid payments" do
     it "shows an error with a missing credit card number" do
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-      within_frame(find '#card_expiry iframe') do
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_expiry iframe') do
         '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
       end
       click_button "Save and Continue"
@@ -174,20 +174,20 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "shows an error with a missing expiration date" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '4242 4242 4242 4242'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration date is incomplete.")
     end
 
     it "shows an error with an invalid credit card number" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '1111 1111 1111 1111'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-      within_frame(find '#card_expiry iframe') do
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_expiry iframe') do
         '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
       end
       click_button "Save and Continue"
@@ -195,11 +195,11 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "shows an error with invalid security fields" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '4242 4242 4242 4242'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '12' }
-      within_frame(find '#card_expiry iframe') do
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '12' }
+      within_frame(find '#stripe_card_expiry iframe') do
         '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
       end
       click_button "Save and Continue"
@@ -207,11 +207,11 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "shows an error with invalid expiry fields" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '4242 4242 4242 4242'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-      within_frame(find '#card_expiry iframe') { fill_in 'exp-date', with: "013" }
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_expiry iframe') { fill_in 'exp-date', with: "013" }
       click_button "Save and Continue"
       expect(page).to have_content("Your card's expiration date is incomplete.")
     end
@@ -227,11 +227,11 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "can process a valid payment" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '4242 4242 4242 4242'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-      within_frame(find '#card_expiry iframe') do
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_expiry iframe') do
         '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
       end
       click_button "Save and Continue"
@@ -241,11 +241,11 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     it "can re-use saved cards" do
-      within_frame find('#card_number iframe') do
+      within_frame find('#stripe_card_number iframe') do
         '4242 4242 4242 4242'.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-      within_frame(find '#card_expiry iframe') do
+      within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+      within_frame(find '#stripe_card_expiry iframe') do
         '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
       end
       click_button "Save and Continue"
@@ -318,11 +318,11 @@ RSpec.describe "Stripe checkout", type: :feature do
       let(:card_number) { "4000 0000 0000 9995" }
 
       it "fails the payment" do
-        within_frame find('#card_number iframe') do
+        within_frame find('#stripe_card_number iframe') do
           card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
         end
-        within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-        within_frame(find '#card_expiry iframe') do
+        within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+        within_frame(find '#stripe_card_expiry iframe') do
           '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
         end
 
@@ -336,11 +336,11 @@ RSpec.describe "Stripe checkout", type: :feature do
       let(:card_number) { "4000 0084 0000 1629" }
 
       it "fails the payment" do
-        within_frame find('#card_number iframe') do
+        within_frame find('#stripe_card_number iframe') do
           card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
         end
-        within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-        within_frame(find '#card_expiry iframe') do
+        within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+        within_frame(find '#stripe_card_expiry iframe') do
           '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
         end
 
@@ -424,11 +424,11 @@ RSpec.describe "Stripe checkout", type: :feature do
         let(:regular_card) { "4242 4242 4242 4242"}
 
         it "voids the first stripe payment and successfully pays with 3DS card" do
-          within_frame find('#card_number iframe') do
+          within_frame find('#stripe_card_number iframe') do
             regular_card.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
           end
-          within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-          within_frame(find '#card_expiry iframe') do
+          within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+          within_frame(find '#stripe_card_expiry iframe') do
             '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
           end
           click_button "Save and Continue"
@@ -495,11 +495,11 @@ RSpec.describe "Stripe checkout", type: :feature do
   end
 
   def authenticate_3d_secure_card(card_number)
-    within_frame find('#card_number iframe') do
+    within_frame find('#stripe_card_number iframe') do
       card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
     end
-    within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-    within_frame(find '#card_expiry iframe') do
+    within_frame(find '#stripe_card_cvc iframe') { fill_in 'cvc', with: '123' }
+    within_frame(find '#stripe_card_expiry iframe') do
       '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
     end
     click_button "Save and Continue"


### PR DESCRIPTION
When the gem is installed into solidus, the default payment gateway needs to be
disabled to make the solidus_stripe js to work. This is due to ids conflict.
This commit differentiate the stripe's payment form fields ids so it can cohexist
with the default payment gateway.