### PR TITLE
Remove credit cards image

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -1,6 +1,5 @@
 <div id="payment-request-button" data-stripe-config="<%= payment_method.stripe_config(current_order).to_json %>" data-v3-api="<%= stripe_v3_api %>"></div>
 
-<%= image_tag 'credit_cards/credit_card.gif', id: 'credit-card-image' %>
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
 <div class="field field-required">


### PR DESCRIPTION
The coming soon alternative/replacement of solidus frontend,
solidus_starter_frontend, will not provide this image in its assets.
Furthermore, this is a low res image that most of the time gets deleted
since the early stages of customization.