### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,11 @@ Stripe account to receive payments via Apple Pay.
 It's possible to pay with Apple Pay and Google Pay directly from the cart
 page. The functionality is self-contained in the view partial
 `_stripe_payment_request_button.html.erb`. In order to use it, you need
-to load that partial in the `orders#edit` frontend page, and pass it the
+to render that partial in the `orders#edit` frontend page, and pass it the
 payment method configured for Stripe via the local variable
-`cart_checkout_payment_method`, for example using `deface`:
+`cart_checkout_payment_method`:
 
 ```ruby
-# app/overrides/spree/orders/edit/add_payment_request_button.html.erb.deface
-
-<!-- insert_after '[data-hook="cart_container"]' -->
 <%= render 'stripe_payment_request_button', cart_checkout_payment_method: Spree::PaymentMethod::StripeCreditCard.first %>
 ```
 


### PR DESCRIPTION
We want to discourage the use of deface since we removed all the
data-hooks attributes from the coming soon solidus_starter_frontend.
A plain render is the better choice.