### PR TITLE
Try to find address state also by name

### DIFF
--- a/app/models/solidus_stripe/address_from_params_service.rb
+++ b/app/models/solidus_stripe/address_from_params_service.rb
@@ -43,7 +43,10 @@ module SolidusStripe
     end
 
     def state
-      @state ||= country.states.find_by_abbr(address_params[:region])
+      @state ||= begin
+        region = address_params[:region]
+        country.states.find_by(abbr: region) || country.states.find_by(name: region)
+      end
     end
 
     def default_attributes

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -505,7 +505,9 @@ RSpec.describe "Stripe checkout", type: :feature do
   def within_3d_secure_modal
     within_frame "__privateStripeFrame11" do
       within_frame "__stripeJSChallengeFrame" do
-        yield
+        within_frame "acsFrame" do
+          yield
+        end
       end
     end
   end

--- a/spec/models/solidus_stripe/address_from_params_service_spec.rb
+++ b/spec/models/solidus_stripe/address_from_params_service_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
         recipient: 'Clark Kent',
         city: 'Metropolis',
         postalCode: '12345',
-        addressLine: [ '12, Lincoln Rd']
+        addressLine: [ '12, Lincoln Rd'],
+        phone: '555-555-0199'
       }
     end
 
@@ -39,7 +40,8 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
             firstname: 'Clark',
             lastname: 'Kent',
             address1: params[:addressLine].first,
-            address2: nil
+            address2: nil,
+            phone: '555-555-0199'
           )
         end
 
@@ -50,11 +52,23 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
 
       context "when no user's address is compatible with the params" do
         before do
-          user.addresses << create(:address)
+          user.addresses << create(:address, state: state)
         end
 
-        it "returns a non-persisted address model" do
-          expect(subject).to be_new_record
+        it "returns a non-persisted valid address" do
+          aggregate_failures do
+            expect(subject).to be_new_record
+            expect(subject).to be_valid
+            expect(subject.state).to eq state
+          end
+        end
+
+        context "when the region is the state name" do
+          before { params[:region] = state.name }
+
+          it "still can set the address state attribute" do
+            expect(subject.state).to eq state
+          end
         end
       end
     end


### PR DESCRIPTION
There have been reports about `AddressFromParamsService` not being able to find the address state by using the `abbr` field. In those instances the provided `region` parameter matched the state name.

Also, small improvements in specs ensure tests are more accurate.