### PR TITLE
Remove server and test_mode from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ Spree.config do |config|
     publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
     stripe_country: 'US',
     v3_elements: false,
-    v3_intents: false,
-    server: Rails.env.production? ? 'production' : 'test',
-    test_mode: !Rails.env.production?
+    v3_intents: false
   )
 end
 ```
@@ -100,9 +98,7 @@ Spree.config do |config|
     publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
     stripe_country: 'US',
     v3_elements: false,
-    v3_intents: true,
-    server: Rails.env.production? ? 'production' : 'test',
-    test_mode: !Rails.env.production?
+    v3_intents: true
   )
 end
 ```


### PR DESCRIPTION
As it turns out, neither of these values are used by any of the Stripe gateway code. They aren't referenced anywhere in this extension nor in either of the `ActiveMerchant` gateways. [1,2] Including them only serves to confuse users. (I know I was certainly confused when I came across some configuration that had them set to use "production" when they were instead connecting to a sandbox account.)


1. https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/stripe.rb
2. https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/stripe_payment_intents.rb