### PR TITLE
Relax solidus_support version dependency

### DIFF
--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   s.add_dependency 'solidus_core', ['>= 2.3', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '~> 0.4'
   # ActiveMerchant v1.58 through v1.59 introduced a breaking change
   # to the stripe gateway.
   #

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -488,8 +488,10 @@ RSpec.describe "Stripe checkout", type: :feature do
 
   def within_3d_secure_modal
     within_frame "__privateStripeFrame10" do
-      within_frame "challengeFrame" do
-        yield
+      within_frame "__stripeJSChallengeFrame" do
+        within_frame "acsFrame" do
+          yield
+        end
       end
     end
   end


### PR DESCRIPTION
Many Solidus extensions already require Solidus Support with version 0.5.x, making this version of Solidus Stripe not compatible with them.