### PR TITLE
Fix 3DS modal amount verification

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -523,7 +523,7 @@ RSpec.describe "Stripe checkout", type: :feature do
     click_button "Save and Continue"
 
     within_3d_secure_modal do
-      expect(page).to have_content '$19.99 using 3D Secure'
+      expect(page).to have_content '$19.99 USD using 3D Secure'
 
       click_button 'Complete authentication'
     end


### PR DESCRIPTION
Stripe recently changed the amount message displayed to the customer in the 3D-Secure modal window.