### PR TITLE
Fix StripeCreditCard#try_void with Elements/V2 API

### DIFF
--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -92,7 +92,7 @@ module Spree
             reason: payment_intents_refund_reason
           ).response
         else
-          payment.void_transaction!
+          void(payment.response_code, nil, nil)
         end
       end
 

--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -248,7 +248,7 @@ describe Spree::PaymentMethod::StripeCreditCard do
 
     shared_examples 'voids the payment transaction' do
       it 'voids the payment transaction' do
-        expect(payment).to receive(:void_transaction!)
+        expect(gateway).to receive(:void)
 
         subject.try_void(payment)
       end


### PR DESCRIPTION
`Payment::Cancellation#cancel` calls StripeCreditCard#try_void`.

When not using Payment Intents (ie. when using Elements or V2 API), after calling `try_void`, the former makes the following call:

    payment.send(:handle_void_response, response)

which is already called by `payment.void_transaction!`, making the two incompatible, as `#handle_void_response` cannot be called twice here - it would raise the error:

    NoMethodError: undefined method `success?' for true:TrueClass

Under the hood `#void_transaction!` calls `payment_method.void`, so the new code is rather equivalent to the previous one. The only relevant feature we're losing is that `#void_transaction!` wraps the call in a `protect_from_connection_error` block.

The modified integration spec verifies that an order created with Elements can be canceled without raising the error mentioned above.