### PR TITLE
Fix non-breaking space character in comment

### DIFF
--- a/spec/support/solidus_address_helper.rb
+++ b/spec/support/solidus_address_helper.rb
@@ -2,7 +2,7 @@
 
 # Since https://github.com/solidusio/solidus/pull/3524 was merged,
 # we need to verify if we're using the single "Name" field or the
-# previous first/last name combination.
+# previous first/last name combination.
 module SolidusAddressNameHelper
   def fill_in_name
     if Spree::Config.preferences[:use_combined_first_and_last_name_in_address]


### PR DESCRIPTION
This replaces a non-breaking space character (`\x{A0}`) with a normal space character.