### PR TITLE
Refactor spec with fill_in_card helper

### DIFF
--- a/lib/solidus_stripe/testing_support/card_input_helper.rb
+++ b/lib/solidus_stripe/testing_support/card_input_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusCardHelper
+module SolidusCardInputHelper
   def fill_in_card(card = {})
     card[:number] ||= "4242 4242 4242 4242"
     card[:code] ||= "123"

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -307,17 +307,8 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     context "when using a card without enough money" do
-      let(:card_number) { "4000 0000 0000 9995" }
-
       it "fails the payment" do
-        within_frame find('#card_number iframe') do
-          card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
-        end
-        within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-        within_frame(find '#card_expiry iframe') do
-          '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
-        end
-
+        fill_in_card({ number: "4000 0000 0000 9995" })
         click_button "Save and Continue"
 
         expect(page).to have_content "Your card has insufficient funds."
@@ -325,17 +316,8 @@ RSpec.describe "Stripe checkout", type: :feature do
     end
 
     context "when entering the wrong 3D verification code" do
-      let(:card_number) { "4000 0084 0000 1629" }
-
       it "fails the payment" do
-        within_frame find('#card_number iframe') do
-          card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
-        end
-        within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-        within_frame(find '#card_expiry iframe') do
-          '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
-        end
-
+        fill_in_card({ number: "4000 0084 0000 1629" })
         click_button "Save and Continue"
 
         within_3d_secure_modal do
@@ -435,7 +417,7 @@ RSpec.describe "Stripe checkout", type: :feature do
           fill_in_card({ number: regular_card })
           click_button "Save and Continue"
 
-          expect(page).to have_content "Ending in 4242"
+          expect(page).to have_content "Ending in #{regular_card.last(4)}"
 
           click_link "Payment"
 
@@ -499,13 +481,7 @@ RSpec.describe "Stripe checkout", type: :feature do
   end
 
   def authenticate_3d_secure_card(card_number)
-    within_frame find('#card_number iframe') do
-      card_number.split('').each { |n| find_field('cardnumber').native.send_keys(n) }
-    end
-    within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: '123' }
-    within_frame(find '#card_expiry iframe') do
-      '0132'.split('').each { |n| find_field('exp-date').native.send_keys(n) }
-    end
+    fill_in_card({ number: card_number })
     click_button "Save and Continue"
 
     within_3d_secure_modal do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,10 +18,13 @@ Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 # Requires factories defined in lib/solidus_stripe/factories.rb
 require 'solidus_stripe/factories'
 
+# Requires card input helper defined in lib/solidus_stripe/testing_support/card_input_helper.rb
+require 'solidus_stripe/testing_support/card_input_helper'
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   FactoryBot.find_definitions
   config.use_transactional_fixtures = false
   config.include SolidusAddressNameHelper, type: :feature
-  config.include SolidusCardHelper, type: :feature
+  config.include SolidusCardInputHelper, type: :feature
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,5 @@ RSpec.configure do |config|
   FactoryBot.find_definitions
   config.use_transactional_fixtures = false
   config.include SolidusAddressNameHelper, type: :feature
+  config.include SolidusCardHelper, type: :feature
 end

--- a/spec/support/solidus_card_helper.rb
+++ b/spec/support/solidus_card_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SolidusCardHelper
+  def fill_in_card(card = {})
+    card[:number] ||= "4242 4242 4242 4242"
+    card[:code] ||= "123"
+    card[:exp_month] ||= "01"
+    card[:exp_year] ||= "#{Time.zone.now.year + 1}"
+
+    if preferred_v3_elements || preferred_v3_intents
+      within_frame find('#card_number iframe') do
+        card[:number].split('').each { |n| find_field('cardnumber').native.send_keys(n) }
+      end
+      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: card[:code] }
+      within_frame(find '#card_expiry iframe') do
+        "#{card[:exp_month]}#{card[:exp_year].last(2)}".split('').each { |n| find_field('exp-date').native.send_keys(n) }
+      end
+    else
+      fill_in "Card Number", with: card[:number]
+      fill_in "Card Code", with: card[:code]
+      fill_in "Expiration", with: "#{card[:exp_month]} / #{card[:exp_year]}"
+    end
+  end
+end


### PR DESCRIPTION
Following the example of [solidus_address_helper.rb](https://github.com/solidusio/solidus_stripe/blob/master/spec/support/solidus_address_helper.rb), this creates a card helper which makes for more concise specs. It can be shared across both V2 and V3 Elements implementations.

It also helps to clarify which card input data is simply the defaults, and which is data specific to that particular spec.