### PR TITLE
Fixes Rails 6.1 load warnings

### DIFF
--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -28,7 +28,7 @@ module SolidusStripe
     end
 
     initializer "spree.payment_method.add_stripe_credit_card", after: "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods << Spree::PaymentMethod::StripeCreditCard
+      app.config.spree.payment_methods << "Spree::PaymentMethod::StripeCreditCard"
     end
   end
 end


### PR DESCRIPTION
**Description**

With Zeitwerk classes shouldn't be loaded before autoloading is enabled (i.e. from initializers). 

The following appears in the logfile:
> DEPRECATION WARNING: Initialization autoloaded the constants Spree::RansackableAttributes, Spree::Base, Spree::PaymentMethod, Spree::PaymentMethod::CreditCard, and Spree::PaymentMethod::StripeCreditCard.
>
>  Being able to do this is deprecated. Autoloading during initialization is going
  to be an error condition in future versions of Rails.
>
>  Reloading does not reboot the application, and therefore code executed during
  initialization does not run again. So, if you reload Spree::RansackableAttributes, for example,
  the expected changes won't be reflected in that stale Module object.
>
>  These autoloaded constants have been unloaded.

This PR changes the initialization to use a string to match the solidus initialization here https://github.com/solidusio/solidus/blob/master/core/lib/spree/app_configuration.rb#L562-L567 