### PR TITLE
Add missing 'var'

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
@@ -50,7 +50,7 @@
         };
         paymentRequest.on('paymentmethod', onPrPaymentMethod.bind(this));
 
-        onShippingAddressChange = function(ev) {
+        var onShippingAddressChange = function(ev) {
           var showError = this.showError.bind(this);
 
           fetch('/stripe/shipping_rates', {


### PR DESCRIPTION
The `onShippingAddressChange` function is missing a `var` keyword which results in an implicit global and causes a strict mode violation.

There doesn't appear to be any code depending on this behaviour so I assume this is a simple fix.