### PR TITLE
Fix 3DS iframe selection

### DIFF
--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe "Stripe checkout", type: :feature do
   end
 
   def within_3d_secure_modal
-    within_frame "__privateStripeFrame11" do
+    within_frame find("iframe[src*='authorize-with-url-inner']") do
       within_frame "__stripeJSChallengeFrame" do
         within_frame "acsFrame" do
           yield

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -271,7 +271,9 @@ RSpec.describe "Stripe checkout", type: :feature do
             expect(page).to have_content "Completed"
           end
 
-          find('input[value="Cancel"]').click
+          page.accept_alert do
+            find('input[value="Cancel"]').click
+          end
 
           expect(page).to have_content "Order canceled"
 
@@ -396,7 +398,9 @@ RSpec.describe "Stripe checkout", type: :feature do
             expect(page).to have_content "Completed"
           end
 
-          find('input[value="Cancel"]').click
+          page.accept_alert do
+            find('input[value="Cancel"]').click
+          end
 
           expect(page).to have_content "Order canceled"
 

--- a/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
 
     context "when there are previous pending payments" do
       let!(:payment) do
-        create(:payment, order: order).tap do |payment|
+        create(:payment, order: order, amount: order.total).tap do |payment|
           payment.update!(state: :pending)
         end
       end


### PR DESCRIPTION
This fix should bring the gem CI back to green status.

Stripe is now using random names for their iframe containers, so we need to resort to some other strategy for finding the iframe that contains the one named `__stripeJSChallengeFrame`.

Currently, one reliable way to find this iframe is by using a non-changing part of its `src` attribute.