### PR TITLE
Enable code linter for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,18 @@ jobs:
     executor: solidusio_extensions/mysql
     steps:
       - solidusio_extensions/run-tests
+  lint-code:
+    executor: solidusio_extensions/sqlite-memory
+    steps:
+      - solidusio_extensions/lint-code
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
       - run-specs-with-postgres
       - run-specs-with-mysql
+      - lint-code
+
   "Weekly run specs against master":
     triggers:
       - schedule:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,2 @@
 require:
   - solidus_dev_support/rubocop
-
-AllCops:
-  Exclude:
-    - sandbox/**/*
-    - spec/dummy/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,15 @@
 require:
   - solidus_dev_support/rubocop
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.4
+Layout/LineLength:
+  Exclude:
+    - db/migrate/*.rb
+Rails/Output:
+  Exclude:
+    - db/seeds.rb
+Rails/SkipsModelValidations:
+  Enabled: false
+RSpec:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,8 @@ else
 end
 
 group :development, :test do
-  gem "pry-rails"
   gem "ffaker"
+  gem "pry-rails"
   gem "rails-controller-testing"
 end
 

--- a/app/controllers/solidus_stripe/payment_request_controller.rb
+++ b/app/controllers/solidus_stripe/payment_request_controller.rb
@@ -14,7 +14,8 @@ module SolidusStripe
       if rates.any?
         render json: { success: true, shipping_rates: rates }
       else
-        render json: { success: false, error: 'No shipping method available for that address' }, status: 500
+        render json: { success: false, error: 'No shipping method available for that address' },
+               status: :internal_server_error
       end
     end
 
@@ -32,10 +33,11 @@ module SolidusStripe
         if current_order.payment?
           render json: { success: true }
         else
-          render json: { success: false, error: 'Order not ready for payment. Try manual checkout.' }, status: 500
+          render json: { success: false, error: 'Order not ready for payment. Try manual checkout.' },
+                 status: :internal_server_error
         end
       else
-        render json: { success: false, error: address.errors.full_messages.to_sentence }, status: 500
+        render json: { success: false, error: address.errors.full_messages.to_sentence }, status: :internal_server_error
       end
     end
   end

--- a/app/decorators/models/spree/order_update_attributes_decorator.rb
+++ b/app/decorators/models/spree/order_update_attributes_decorator.rb
@@ -25,9 +25,9 @@ module Spree
     end
 
     def paying_with_stripe_intents?
-      if id = payments_attributes.first&.dig(:payment_method_id)
-        stripe_intents?(Spree::PaymentMethod.find(id))
-      end
+      return unless id = payments_attributes.first&.dig(:payment_method_id)
+
+      stripe_intents?(Spree::PaymentMethod.find(id))
     end
 
     def stripe_intents?(payment_method)

--- a/app/models/solidus_stripe/address_from_params_service.rb
+++ b/app/models/solidus_stripe/address_from_params_service.rb
@@ -39,7 +39,7 @@ module SolidusStripe
     end
 
     def country
-      @country ||= Spree::Country.find_by_iso(address_params[:country])
+      @country ||= Spree::Country.find_by(iso: address_params[:country])
     end
 
     def state

--- a/app/models/solidus_stripe/create_intents_payment_service.rb
+++ b/app/models/solidus_stripe/create_intents_payment_service.rb
@@ -33,9 +33,9 @@ module SolidusStripe
     end
 
     def invalidate_previous_payment_intents_payments
-      if stripe.v3_intents?
-        current_order.payments.pending.where(payment_method: stripe).each(&:void_transaction!)
-      end
+      return unless stripe.v3_intents?
+
+      current_order.payments.pending.where(payment_method: stripe).find_each(&:void_transaction!)
     end
 
     def create_payment
@@ -98,7 +98,8 @@ module SolidusStripe
     end
 
     def address_attributes
-      html_payment_source_data['address_attributes'] || SolidusStripe::AddressFromParamsService.new(form_data).call.attributes
+      html_payment_source_data['address_attributes'] ||
+      SolidusStripe::AddressFromParamsService.new(form_data).call.attributes
     end
 
     def address_full_name

--- a/bin/rails
+++ b/bin/rails
@@ -5,7 +5,7 @@
 app_root = 'spec/dummy'
 
 unless File.exist? "#{app_root}/bin/rails"
-  system "bin/rake", app_root or begin # rubocop:disable Style/AndOr
+  system "bin/rake", app_root or begin
     warn "Automatic creation of the dummy app failed"
     exit 1
   end

--- a/bin/sandbox_rails
+++ b/bin/sandbox_rails
@@ -7,7 +7,7 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    system "#{__dir__}/sandbox" or begin # rubocop:disable Style/AndOr
+    system "#{__dir__}/sandbox" or begin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end

--- a/lib/generators/solidus_stripe/install/install_generator.rb
+++ b/lib/generators/solidus_stripe/install/install_generator.rb
@@ -10,10 +10,6 @@ module SolidusStripe
       end
 
       def add_migrations
-        run 'bundle exec rake railties:install:migrations FROM=solidus_stripe'
-      end
-
-      def add_migrations
         run 'bin/rails railties:install:migrations FROM=solidus_stripe'
       end
 

--- a/lib/solidus_stripe/testing_support/card_input_helper.rb
+++ b/lib/solidus_stripe/testing_support/card_input_helper.rb
@@ -5,15 +5,16 @@ module SolidusCardInputHelper
     card[:number] ||= "4242 4242 4242 4242"
     card[:code] ||= "123"
     card[:exp_month] ||= "01"
-    card[:exp_year] ||= "#{Time.zone.now.year + 1}"
+    card[:exp_year] ||= (Time.zone.now.year + 1).to_s
 
     if preferred_v3_elements || preferred_v3_intents
       within_frame find('#card_number iframe') do
         card[:number].split('').each { |n| find_field('cardnumber').native.send_keys(n) }
       end
-      within_frame(find '#card_cvc iframe') { fill_in 'cvc', with: card[:code] }
-      within_frame(find '#card_expiry iframe') do
-        "#{card[:exp_month]}#{card[:exp_year].last(2)}".split('').each { |n| find_field('exp-date').native.send_keys(n) }
+      within_frame(find('#card_cvc iframe')) { fill_in 'cvc', with: card[:code] }
+      within_frame(find('#card_expiry iframe')) do
+        "#{card[:exp_month]}#{card[:exp_year].last(2)}".split('')
+                                                       .each { |n| find_field('exp-date').native.send_keys(n) }
       end
     else
       fill_in "Card Number", with: card[:number]

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'activemerchant', '>= 1.100'
   spec.add_dependency 'solidus_core', ['>= 2.3', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
-  spec.add_dependency 'activemerchant', '>= 1.100'
 
   spec.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -474,12 +474,10 @@ RSpec.describe "Stripe checkout", type: :feature do
     it_behaves_like "Stripe Elements invalid payments"
   end
 
-  def within_3d_secure_modal
+  def within_3d_secure_modal(&block)
     within_frame find("iframe[src*='authorize-with-url-inner']") do
       within_frame "__stripeJSChallengeFrame" do
-        within_frame "acsFrame" do
-          yield
-        end
+        within_frame "acsFrame", &block
       end
     end
   end

--- a/spec/models/solidus_stripe/address_from_params_service_spec.rb
+++ b/spec/models/solidus_stripe/address_from_params_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
         recipient: 'Clark Kent',
         city: 'Metropolis',
         postalCode: '12345',
-        addressLine: [ '12, Lincoln Rd'],
+        addressLine: ['12, Lincoln Rd'],
         phone: '555-555-0199'
       }
     end
@@ -36,12 +36,12 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
         before do
           user.addresses << create(
             :address, city: params[:city],
-            zipcode: params[:postalCode],
-            firstname: 'Clark',
-            lastname: 'Kent',
-            address1: params[:addressLine].first,
-            address2: nil,
-            phone: '555-555-0199'
+                      zipcode: params[:postalCode],
+                      firstname: 'Clark',
+                      lastname: 'Kent',
+                      address1: params[:addressLine].first,
+                      address2: nil,
+                      phone: '555-555-0199'
           )
         end
 

--- a/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
@@ -38,23 +38,23 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
 
   let(:intent) do
     double(params: {
-      "id" => intent_id,
-      "charges" => {
-        "data" => [{
-          "billing_details" => {
-            "name" => "John Doe"
-          },
-          "payment_method_details" => {
-            "card" => {
-              "brand" => "visa",
-              "exp_month" => 1,
-              "exp_year" => 2022,
-              "last4" => "4242"
-            },
-          }
-        }]
-      }
-    })
+             "id" => intent_id,
+             "charges" => {
+               "data" => [{
+                 "billing_details" => {
+                   "name" => "John Doe"
+                 },
+                 "payment_method_details" => {
+                   "card" => {
+                     "brand" => "visa",
+                     "exp_month" => 1,
+                     "exp_year" => 2022,
+                     "last4" => "4242"
+                   },
+                 }
+               }]
+             }
+           })
   end
 
   describe '#call' do
@@ -69,12 +69,12 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
     it { expect(subject).to be true }
 
     it "creates a new pending payment" do
-      expect { subject }.to change { order.payments.count }
+      expect { subject }.to change(order.payments, :count)
       expect(order.payments.last.reload).to be_pending
     end
 
     it "creates a credit card with the correct information" do
-      expect { subject }.to change { Spree::CreditCard.count }
+      expect { subject }.to change(Spree::CreditCard, :count)
       card = Spree::CreditCard.last
 
       aggregate_failures do
@@ -119,7 +119,7 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
 
       context "when none is a Payment Intent" do
         it "does not invalidate them" do
-          expect { subject }.not_to change { payment.reload.state }
+          expect { subject }.not_to change(payment.reload, :state)
         end
       end
     end

--- a/spec/models/solidus_stripe/prepare_order_for_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/prepare_order_for_payment_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SolidusStripe::PrepareOrderForPaymentService do
 
     it "sets the order ship and bill address" do
       expect { subject }.to change { order.ship_address }.to(address)
-        .and change { order.bill_address }.to(address)
+                                                         .and change { order.bill_address }.to(address)
     end
 
     context "when the user is not logged in" do
@@ -58,7 +58,7 @@ RSpec.describe SolidusStripe::PrepareOrderForPaymentService do
       before { order.line_items.destroy_all }
 
       it "leaves the order to a previous state" do
-        expect { subject }.not_to change { order.state }
+        expect { subject }.not_to change(order, :state)
       end
     end
   end

--- a/spec/models/solidus_stripe/shipping_rates_service_spec.rb
+++ b/spec/models/solidus_stripe/shipping_rates_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SolidusStripe::ShippingRatesService do
   let(:ca_warehouse) { create(:stock_location, name: "CA Warehouse", shipping_methods: [air_mail]) }
 
   before do
-    2.times { create :inventory_unit, order: order }
+    create_list :inventory_unit, 2, order: order
     Spree::StockLocation.update_all backorderable_default: false
     Spree::StockItem.find_by(stock_location: fl_warehouse, variant: order.variants.first).set_count_on_hand(1)
     Spree::StockItem.find_by(stock_location: ca_warehouse, variant: order.variants.last).set_count_on_hand(1)

--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -15,16 +15,14 @@ describe Spree::PaymentMethod::StripeCreditCard do
       bill_address: bill_address,
       currency: 'USD',
       number: 'NUMBER',
-      total: 10.99
-    )
+      total: 10.99)
   }
 
   let(:payment) {
     double('Spree::Payment',
       source: source,
       order: order,
-      amount: order.total
-    )
+      amount: order.total)
   }
 
   let(:gateway) do
@@ -95,18 +93,18 @@ describe Spree::PaymentMethod::StripeCreditCard do
 
       it 'stores the bill address with the gateway' do
         expect(subject.gateway).to receive(:store).with(payment.source, {
-          email: email,
-          login: secret_key,
+                                                          email: email,
+                                                          login: secret_key,
 
-          address: {
-            address1: '123 Happy Road',
-            address2: 'Apt 303',
-            city: 'Suzarac',
-            zip: '95671',
-            state: 'Oregon',
-            country: 'United States'
-          }
-        }).and_return double.as_null_object
+                                                          address: {
+                                                            address1: '123 Happy Road',
+                                                            address2: 'Apt 303',
+                                                            city: 'Suzarac',
+                                                            zip: '95671',
+                                                            state: 'Oregon',
+                                                            country: 'United States'
+                                                          }
+                                                        }).and_return double.as_null_object
 
         subject.create_profile payment
       end
@@ -115,9 +113,9 @@ describe Spree::PaymentMethod::StripeCreditCard do
     context 'with an order that does not have a bill address' do
       it 'does not store a bill address with the gateway' do
         expect(subject.gateway).to receive(:store).with(payment.source, {
-          email: email,
-          login: secret_key,
-        }).and_return double.as_null_object
+                                                          email: email,
+                                                          login: secret_key,
+                                                        }).and_return double.as_null_object
 
         subject.create_profile payment
       end
@@ -154,7 +152,8 @@ describe Spree::PaymentMethod::StripeCreditCard do
       let(:bill_address) { nil }
 
       it 'stores the profile_id as a card' do
-        expect(subject.gateway).to receive(:store).with(source.gateway_payment_profile_id, anything).and_return double.as_null_object
+        expect(subject.gateway).to receive(:store).with(source.gateway_payment_profile_id, anything)
+                                                  .and_return double.as_null_object
 
         subject.create_profile payment
       end
@@ -229,9 +228,9 @@ describe Spree::PaymentMethod::StripeCreditCard do
 
     let!(:success_response) do
       double('success_response', success?: true,
-                               authorization: '123',
-                               avs_result: { 'code' => 'avs-code' },
-                               cvv_result: { 'code' => 'cvv-code', 'message' => "CVV Result" })
+                                 authorization: '123',
+                                 avs_result: { 'code' => 'avs-code' },
+                                 cvv_result: { 'code' => 'cvv-code', 'message' => "CVV Result" })
     end
 
     after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require 'solidus_dev_support/rspec/feature_helper'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].sort.each { |f| require f }
 
 # Requires factories defined in lib/solidus_stripe/factories.rb
 require 'solidus_stripe/factories'


### PR DESCRIPTION
Rubocop was reporting a lot of offenses. This PR enables the lint code step provided by the `solidusio_extensions` Circle CI orb and fixes some of the offenses.

I disable some cops that I think we should discuss if we want or not at this point. But for now, I believe we could benefit from an initial version of the lint.