### PR TITLE
Retrieve phone number paying with digital wallets

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-cart-page-checkout.js
@@ -53,6 +53,7 @@ SolidusStripe.CartPageCheckout.prototype.onPrPayment = function(payment) {
       shipping_option: payment.shippingOption,
       email: payment.payerEmail,
       name: payment.payerName,
+      phone: payment.payerPhone,
       authenticity_token: this.authToken
     })
   }).then(function(response) {

--- a/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
+++ b/app/assets/javascripts/spree/frontend/solidus_stripe/stripe-payment-request-button-shared.js
@@ -22,6 +22,7 @@
           },
           requestPayerName: true,
           requestPayerEmail: true,
+          requestPayerPhone: true,
           requestShipping: config.requestShipping,
           shippingOptions: []
         });

--- a/app/controllers/solidus_stripe/payment_request_controller.rb
+++ b/app/controllers/solidus_stripe/payment_request_controller.rb
@@ -22,7 +22,7 @@ module SolidusStripe
       current_order.restart_checkout_flow
 
       address = SolidusStripe::AddressFromParamsService.new(
-        params[:shipping_address],
+        shipping_address_from_params,
         spree_current_user
       ).call
 
@@ -37,6 +37,16 @@ module SolidusStripe
       else
         render json: { success: false, error: address.errors.full_messages.to_sentence }, status: 500
       end
+    end
+
+    private
+
+    def shipping_address_from_params
+      return {} unless params[:shipping_address]
+      return params[:shipping_address] if params.dig(:shipping_address, :phone).present?
+
+      params[:shipping_address][:phone] = params[:phone]
+      params[:shipping_address]
     end
   end
 end

--- a/spec/requests/payment_requests_spec.rb
+++ b/spec/requests/payment_requests_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Payment Request", type: :request do
+  describe "POST /stripe/update_order" do
+    it "responds with { success: true } when the order is correctly updated" do
+      order = create(:order_ready_to_complete)
+      allow_any_instance_of(SolidusStripe::PaymentRequestController).to receive(:current_order).and_return(order)
+
+      with_disabled_forgery_protection do
+        post "/stripe/update_order", params: stripe_update_request_params(order: order)
+      end
+
+      json = JSON.parse(response.body)
+      expect(json["success"]).to be_truthy
+    end
+  end
+
+  private
+
+  def with_disabled_forgery_protection
+    original_allow_forgery_protection_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+
+    yield
+
+    ActionController::Base.allow_forgery_protection = original_allow_forgery_protection_value
+  end
+
+  def stripe_update_request_params(
+    order:,
+    shipping_address: nil,
+    name: 'Clark Kent',
+    phone: '555-555-0199'
+    )
+
+    {
+      shipping_address: shipping_address || default_shipping_address,
+      shipping_option: {
+        id: order.shipments.first.shipping_rates.first.shipping_method.id
+      },
+      name: name,
+      phone: phone,
+      email: order.email
+    }
+  end
+
+  def default_shipping_address(
+    country: nil,
+    region: nil,
+    recipient: 'Clark Kent',
+    city: 'Metropolis',
+    postal_code: '12345',
+    address_line: ['12, Lincoln Rd'],
+    phone: '555-555-0199'
+    )
+
+    if country.blank? || region.blank?
+      state = create(:state)
+
+      country ||= state.country.iso
+      region ||= state.abbr
+    end
+
+    {
+      country: country,
+      region: region,
+      recipient: recipient,
+      city: city,
+      postalCode: postal_code,
+      addressLine: address_line,
+      phone: phone
+    }
+  end
+end


### PR DESCRIPTION
This PR allows us to save the user's phone number into the order address when we get it back from Apple Pay and Google Pay.