### PR TITLE
Update refund_decorator.rb prepend namespacing

### DIFF
--- a/app/decorators/models/spree/refund_decorator.rb
+++ b/app/decorators/models/spree/refund_decorator.rb
@@ -4,6 +4,6 @@ module Spree
   module RefundDecorator
     attr_reader :response
 
-    Spree::Refund.prepend(self)
+    ::Spree::Refund.prepend(self)
   end
 end


### PR DESCRIPTION
This updates the `refund_decorator.rb` namespacing for consistency with [payment_decorator.rb](https://github.com/solidusio/solidus_stripe/blob/dae5d802f13ea46ced25c3cd812d3844abe40e7e/app/decorators/models/spree/payment_decorator.rb#L9) and [order_update_attributes_decorator.rb](https://github.com/solidusio/solidus_stripe/blob/dae5d802f13ea46ced25c3cd812d3844abe40e7e/app/decorators/models/spree/order_update_attributes_decorator.rb#L37):

https://github.com/solidusio/solidus_stripe/blob/dae5d802f13ea46ced25c3cd812d3844abe40e7e/app/decorators/models/spree/payment_decorator.rb#L9

https://github.com/solidusio/solidus_stripe/blob/dae5d802f13ea46ced25c3cd812d3844abe40e7e/app/decorators/models/spree/order_update_attributes_decorator.rb#L37