### PR TITLE
Remove Solidus 2.x deprecation to allow 3.0 usage

### DIFF
--- a/app/models/solidus_stripe/address_from_params_service.rb
+++ b/app/models/solidus_stripe/address_from_params_service.rb
@@ -26,14 +26,26 @@ module SolidusStripe
           lines = address_params[:addressLine]
           names = address_params[:recipient].split(' ')
 
-          attributes.merge!(
-            state_id: state&.id,
-            firstname: names.first,
-            lastname: names.last,
-            phone: phone,
-            address1: lines.first,
-            address2: lines.second
-          ).reject! { |_, value| value.blank? }
+          name_attributes = if SolidusSupport.combined_first_and_last_name_in_address? && Spree::Address.column_names.include?("name")
+            {
+              name: address_params[:recipient]
+            }
+          else
+            {
+              firstname: names.first,
+              lastname: names.last,
+            }
+          end
+
+          attributes
+            .merge!(name_attributes)
+            .merge!(
+              state_id: state&.id,
+              phone: phone,
+              address1: lines.first,
+              address2: lines.second
+            )
+            .reject! { |_, value| value.blank? }
         end
       end
     end

--- a/app/models/solidus_stripe/create_intents_payment_service.rb
+++ b/app/models/solidus_stripe/create_intents_payment_service.rb
@@ -102,7 +102,8 @@ module SolidusStripe
     end
 
     def address_full_name
-      current_order.bill_address&.full_name || form_data[:recipient]
+      bill_address_name = SolidusSupport.combined_first_and_last_name_in_address? ? current_order.bill_address&.name : current_order.bill_address&.full_name
+      bill_address_name || form_data[:recipient]
     end
 
     def update_stripe_payment_description

--- a/lib/views/frontend/spree/checkout/payment/v2/_javascript.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v2/_javascript.html.erb
@@ -66,7 +66,7 @@
 <%- if @order.has_checkout_step?('address') -%>
   <script>
     Spree.stripeAdditionalInfo = {
-      name: "<%= @order.bill_address.full_name %>",
+      name: "<%= SolidusSupport.combined_first_and_last_name_in_address? ? @order.bill_address.name : @order.bill_address.full_name %>",
       address_line1: "<%= @order.bill_address.address1 %>",
       address_line2: "<%= @order.bill_address.address2 %>",
       address_city: "<%= @order.bill_address.city %>",

--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -1,10 +1,11 @@
 <div id="payment-request-button" data-stripe-config="<%= payment_method.stripe_config(current_order).to_json %>" data-v3-api="<%= stripe_v3_api %>"></div>
 
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
+<% name = SolidusSupport.combined_first_and_last_name_in_address? ? @order.name : "#{@order.billing_firstname} #{@order.billing_lastname}" %>
 
 <div class="field field-required">
   <%= label_tag "name_on_card_#{payment_method.id}", t('spree.name_on_card') %>
-  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name" } %>
+  <%= text_field_tag "#{param_prefix}[name]", name, { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name" } %>
 </div>
 
 <div class="field field-required" data-hook="card_number">

--- a/spec/models/solidus_stripe/address_from_params_service_spec.rb
+++ b/spec/models/solidus_stripe/address_from_params_service_spec.rb
@@ -34,15 +34,26 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
 
       context "when the user has an address compatible with the params" do
         before do
-          user.addresses << create(
-            :address, city: params[:city],
+          name_attributes = if SolidusSupport.combined_first_and_last_name_in_address?
+            {
+              name: 'Clark Kent'
+            }
+          else
+            {
+              firstname: 'Clark',
+              lastname: 'Kent',
+            }
+          end
+
+          address_attributes = {
+            city: params[:city],
             zipcode: params[:postalCode],
-            firstname: 'Clark',
-            lastname: 'Kent',
             address1: params[:addressLine].first,
             address2: nil,
-            phone: '555-555-0199'
-          )
+            phone: '555-555-0199',
+          }.merge!(name_attributes)
+
+          user.addresses << create(:address, address_attributes)
         end
 
         it "returns an existing user's address" do

--- a/spec/support/solidus_address_helper.rb
+++ b/spec/support/solidus_address_helper.rb
@@ -5,7 +5,7 @@
 # previous first/last name combination.
 module SolidusAddressNameHelper
   def fill_in_name
-    if Spree::Config.preferences[:use_combined_first_and_last_name_in_address]
+    if SolidusSupport.combined_first_and_last_name_in_address?
       fill_in "Name", with: "Han Solo"
     else
       fill_in "First Name", with: "Han"


### PR DESCRIPTION
Closes #98 by removing all the deprecation warnings making this gem compatible with Solidus 3.0.

Blocked by https://github.com/solidusio/solidus_stripe/pull/97 and https://github.com/solidusio/solidus/pull/3908.

Co-authored-by: @rainerdema