### PR TITLE
Maintain compatibility with Solidus 3.0 Address#name

### DIFF
--- a/lib/views/frontend/spree/checkout/payment/v2/_javascript.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v2/_javascript.html.erb
@@ -66,7 +66,7 @@
 <%- if @order.has_checkout_step?('address') -%>
   <script>
     Spree.stripeAdditionalInfo = {
-      name: "<%= @order.bill_address.full_name %>",
+      name: "<%= @order.bill_address.try(:full_name) || @order.bill_address.name %>",
       address_line1: "<%= @order.bill_address.address1 %>",
       address_line2: "<%= @order.bill_address.address2 %>",
       address_city: "<%= @order.bill_address.city %>",

--- a/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/v3/_form_elements.html.erb
@@ -4,7 +4,7 @@
 
 <div class="field field-required">
   <%= label_tag "name_on_card_#{payment_method.id}", t('spree.name_on_card') %>
-  <%= text_field_tag "#{param_prefix}[name]", "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name" } %>
+  <%= text_field_tag "#{param_prefix}[name]", @order.try(:billing_name) || "#{@order.billing_firstname} #{@order.billing_lastname}", { id: "name_on_card_#{payment_method.id}", autocomplete: "cc-name" } %>
 </div>
 
 <div class="field field-required" data-hook="card_number">

--- a/spec/models/solidus_stripe/address_from_params_service_spec.rb
+++ b/spec/models/solidus_stripe/address_from_params_service_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe SolidusStripe::AddressFromParamsService do
           user.addresses << create(
             :address, city: params[:city],
             zipcode: params[:postalCode],
-            firstname: 'Clark',
-            lastname: 'Kent',
+            name: 'Clark Kent',
             address1: params[:addressLine].first,
             address2: nil,
             phone: '555-555-0199'

--- a/spec/support/solidus_address_helper.rb
+++ b/spec/support/solidus_address_helper.rb
@@ -5,11 +5,11 @@
 # previous first/last name combination.
 module SolidusAddressNameHelper
   def fill_in_name
-    if Spree::Config.preferences[:use_combined_first_and_last_name_in_address]
-      fill_in "Name", with: "Han Solo"
-    else
+    if has_field?("First Name")
       fill_in "First Name", with: "Han"
       fill_in "Last Name", with: "Solo"
+    else
+      fill_in "Name", with: "Han Solo"
     end
   end
 end


### PR DESCRIPTION
Solidus 3.0 switched from `Address#first_name` and `Address#last_name` to simply `Address#name` -- and also removed the `Address#full_name` accessor for good measure. (See https://github.com/solidusio/solidus/pull/3458)

This caused the `solidus_stripe` specs to fail on the Solidus `master` branch.

This PR accommodates the new Address format in Solidus 3.0 while maintaining backwards compatibility with 2.11, 2.10, and older versions of Solidus. It fixes the specs which are currently broken in Solidus 3.0.