### PR TITLE
Bump minimum solidus_support version requirement

### DIFF
--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'solidus_core', ['>= 2.3', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.5'
+  spec.add_dependency 'solidus_support', '~> 0.8'
   spec.add_dependency 'activemerchant', '>= 1.100'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.3'


### PR DESCRIPTION
This PR bumps `solidus_support` minumum required version to 0.8 because `SolidusSupport::combined_first_and_last_name_in_address?` helper is used in production code and has been implemented in that version.