### PR TITLE
Add statement_descriptor_suffix support to options_for_purchase_or_auth

### DIFF
--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -155,6 +155,7 @@ module Spree
         options[:description] = "Solidus Order ID: #{transaction_options[:order_id]}"
         options[:currency] = transaction_options[:currency]
         options[:off_session] = true if v3_intents?
+        options[:statement_descriptor_suffix] = transaction_options[:statement_descriptor_suffix] if transaction_options[:statement_descriptor_suffix]
 
         if customer = creditcard.gateway_customer_profile_id
           options[:customer] = customer

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'solidus_core', ['>= 2.3', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.8'
-  spec.add_dependency 'activemerchant', '>= 1.100'
+  spec.add_dependency 'activemerchant', '>= 1.105'
 
   spec.add_development_dependency 'solidus_dev_support', '~> 2.3'
 end

--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -284,4 +284,33 @@ describe Spree::PaymentMethod::StripeCreditCard do
       end
     end
   end
+
+  describe '#options_for_purchase_or_auth' do
+    let(:card) do
+      FactoryBot.create(
+        :credit_card,
+        gateway_customer_profile_id: 'cus_abcde',
+        imported: false
+      )
+    end
+
+    before do
+      allow(subject).to receive(:options_for_purchase_or_auth).and_call_original
+    end
+
+    context 'transaction_options' do
+      it 'includes basic values and keys' do
+        options = subject.send(:options_for_purchase_or_auth, 19.99, card, {})
+        expect(options[0]).to eq(19.99)
+        expect(options[1]).to eq(card)
+        expect(options[2].keys).to eq([:description, :currency, :customer])
+      end
+
+      it 'includes statement_descriptor_suffix within options' do
+        transaction_options = { statement_descriptor_suffix: 'FFFFFFF' }
+        options = subject.send(:options_for_purchase_or_auth, 19.99, card, transaction_options)
+        expect(options.last[:statement_descriptor_suffix]).to eq('FFFFFFF')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add support for `statement_descriptor_suffix`

https://github.com/activemerchant/active_merchant/releases/tag/v1.105.0