### PR TITLE
Revert "Add back custom view paths that were mistakenly removed"

### DIFF
--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -16,10 +16,6 @@ module SolidusStripe
       g.test_framework :rspec
     end
 
-    paths["app/views"] << "lib/views/backend" if SolidusSupport.backend_available?
-    paths["app/views"] << "lib/views/frontend" if SolidusSupport.frontend_available?
-    paths["app/views"] << "lib/views/api" if SolidusSupport.api_available?
-
     initializer "spree.payment_method.add_stripe_credit_card", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << "Spree::PaymentMethod::StripeCreditCard"
     end

--- a/spec/features/stripe_checkout_spec.rb
+++ b/spec/features/stripe_checkout_spec.rb
@@ -315,14 +315,14 @@ RSpec.describe "Stripe checkout", type: :feature do
           click_button 'Complete authentication'
         end
 
-        expect(page).to have_content "Your card was declined."
+        expect(page).to have_content "Your card has been declined."
       end
     end
 
     context "when reusing a card" do
       stub_authorization!
 
-      it "succesfully creates a second payment that can be captured in the backend" do
+      it "successfully creates a second payment that can be captured in the backend" do
         authenticate_3d_secure_card(card_3d_secure)
 
         expect(page).to have_current_path("/checkout/confirm")


### PR DESCRIPTION
Reverts solidusio/solidus_stripe#128

Turns out this is already taken care by solidus_support and https://github.com/solidusio/solidus_stripe/issues/127 is due to something else. I'm opening this revert PR as a reminder that we need to address solidus_starter_frontend support.