### PR TITLE
Fix setup instructions for Rails 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ variables you can create the following static configuration:
 
 ```ruby
 # config/initializers/spree.rb
-
-Spree.config do |config|
-  # ...
-
-  config.static_model_preferences.add(
+Rails.application.config.to_prepare do
+  Spree::Config.static_model_preferences.add(
     Spree::PaymentMethod::StripeCreditCard,
     'stripe_env_credentials',
     secret_key: ENV['STRIPE_SECRET_KEY'],


### PR DESCRIPTION
## Summary
> Since Rails 7, it's [no longer possible to reference a loadable constant](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoload-on-boot-and-on-each-reload) on the initialize phase [1]. We need to wrap the setup within a to_prepare block, as it's already [documented in our guides](https://guides.solidus.io/advanced-solidus/model-preferences#static-preferences).

Credits to: @waiting-for-dev

Pretty much a copy of: https://github.com/solidusio/solidus_paypal_braintree/pull/332
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if yuou do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- [x] I have added automated tests to cover my changes.
- [x] I have attached screenshots to demo visual changes.
- [x] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- [x] I have updated the README to account for my changes.
