### PR TITLE
Fix charge amount for currencies without fractions

### DIFF
--- a/app/models/spree/payment_method/stripe_credit_card.rb
+++ b/app/models/spree/payment_method/stripe_credit_card.rb
@@ -61,6 +61,10 @@ module Spree
         true
       end
 
+      def money
+        ActiveMerchant::Billing::Gateway.currencies_without_fractions.include?(order.currency) ? super * 100 : super
+      end
+
       def purchase(money, creditcard, transaction_options)
         gateway.purchase(*options_for_purchase_or_auth(money, creditcard, transaction_options))
       end


### PR DESCRIPTION
Overrides this method: https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/core/app/models/spree/payment.rb#L74
To fix an issue with amounts in currencies without fractions (e.g. JPY) being divided by 100, which happens here: https://github.com/activemerchant/active_merchant/blob/db0e8d4f042b58aaff4af9fefef232f8e7528b8d/lib/active_merchant/billing/gateway.rb#L279

## Summary

I’m using the V1 api for a store in Japanese (JPY currency). Amounts are losing two zeros before being sent to the Stripe/Charges API.

  **My Research:**
The auth trigger happens [here](https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/core/app/models/spree/payment/processing.rb#L37) (called by the state machine)
Sent to the gateway [here](https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/core/app/models/spree/payment/processing.rb#L37)
Money is calculated [here](https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/core/app/models/spree/payment.rb#L82)
It goes through Monetize / RubyMoney using the 'cents' method. That flows through to [here](https://github.com/RubyMoney/money/blob/ca59ced949e4e818262a59ffbcad3ec54affa81f/lib/money/money.rb#L658)

```
This can be seen in practice with something like this:
order = Spree::Order.find('ORDER NUMBER HERE')
amount = order.payments.first.amount
currency = order.currency
Spree::Money.new(amount, {currency: currency})
=> #<Spree::Money:0x000000013b0d9f58 @money=#<Money fractional:14000 currency:JPY>, @options={:sign_before_symbol=>true, :currency=>"JPY"}>
Spree::Money.new(amount, {currency: currency}).money.cents => 14000
```

 All looks good so far…
This is then processed by the gateway [here](https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/stripe.rb#L83)
Turned into a post for the Stripe API starting [here](https://github.com/activemerchant/active_merchant/blob/7fea8f3364ef44187aafa9c5eac3b76438671327/lib/active_merchant/billing/gateways/stripe.rb#L363)
The amount for the post is calculated [here](https://github.com/activemerchant/active_merchant/blob/7fea8f3364ef44187aafa9c5eac3b76438671327/lib/active_merchant/billing/gateways/stripe.rb#L403)
**[The amount is localized here](https://github.com/activemerchant/active_merchant/blob/db0e8d4f042b58aaff4af9fefef232f8e7528b8d/lib/active_merchant/billing/gateway.rb#L279)** 

We can see that JPY is both in the payment (if you interrupt the authorization process to debug, the currency and country and correctly applied), so ‘JPY’ triggers currencies without fractions, which are specified [here](https://github.com/activemerchant/active_merchant/blob/db0e8d4f042b58aaff4af9fefef232f8e7528b8d/lib/active_merchant/billing/gateway.rb#L129 ).

This all posts to [the /charges/ path of the Stripe API](https://stripe.com/docs/api/charges/create)

  So, I think the amount is being converted to a float, then divided by 100, and then plugged into the api post.  For example I have a product that has tax and shipping included that comes to ¥3200. At checkout in dev using a test api key, when going from confirm to complete (as authorize gets called), it’s giving an error that the amount is too low to be charged—¥32. 
  
[I first brought this up on Slack, and was encouraged to give it a go myself](https://solidusio.slack.com/archives/C0JBKDF35/p1669932922971529).
I've never made a (serious) pull request so I apologize if this is long winded or   perhaps hack-y, but the fix I made seems to work.
