### PR TITLE
Fix incorrect charge amount for currencies without fractions

### DIFF
--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -171,9 +171,29 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
   end
 
+  context 'purchasing with fractionless currency' do
+    after do
+      subject.purchase(1999, 'credit card', { currency: 'JPY' })
+    end
+
+    it 'send the payment to the gateway' do
+      expect(gateway).to receive(:purchase).with('money', 'cc', 'opts')
+    end
+  end
+
   context 'authorizing' do
     after do
       subject.authorize(19.99, 'credit card', {})
+    end
+
+    it 'send the authorization to the gateway' do
+      expect(gateway).to receive(:authorize).with('money', 'cc', 'opts')
+    end
+  end
+
+  context 'authorizing with fractionless currency' do
+    after do
+      subject.authorize(1999, 'credit card', { currency: 'JPY' })
     end
 
     it 'send the authorization to the gateway' do
@@ -188,6 +208,20 @@ describe Spree::PaymentMethod::StripeCreditCard do
 
     it 'convert the amount to cents' do
       expect(gateway).to receive(:capture).with(1234, anything, anything)
+    end
+
+    it 'use the response code as the authorization' do
+      expect(gateway).to receive(:capture).with(anything, 'response_code', anything)
+    end
+  end
+
+  context 'capturing with fractionless currency' do
+    after do
+      subject.capture(1234, 'response_code', { currency: 'JPY' })
+    end
+
+    it 'amount not converted to cents' do
+      expect(gateway).to receive(:capture).with(Spree::Money.new(123_400, { currency: 'JPY' }), anything, anything)
     end
 
     it 'use the response code as the authorization' do


### PR DESCRIPTION
## Summary

Fixes #137 
Fixes #138 

This feels really hacky—I'm sure there's a more elegant solution, but this works in my testing environment. I can't figure out why sometimes the 'money' argument is an integer and sometimes is a Spree:Money object in my testing. Maybe it was something else I was messing with (trying to override the 'money' method in Spree::Payment at one point). 

This also provides a Spree::Money object to ActiveMerchant::Billing::Gateway, but it looks like it doesn't want that anymore?https://github.com/activemerchant/active_merchant/blob/7fea8f3364ef44187aafa9c5eac3b76438671327/lib/active_merchant/billing/gateway.rb#L256
