### PR TITLE
Add wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ solidus_stripe:
 
 ## Usage
 
+### Showing reusable sources in the checkout
+
+When saving stripe payment methods for future usage the checkout requires
+a partial for each supported payment method type.
+
+For the full list of types see: https://stripe.com/docs/api/payment_methods/object#payment_method_object-type.
+
+The extension will only install a partial for the `card` type, located in `app/views/checkouts/existing_payment/stripe/_card.html.erb`,
+and fall back to a `default` partial otherwise (see `app/views/checkouts/existing_payment/stripe/_default.html.erb`).
+
+As an example, in order to show a wallet source connected to a
+[SEPA Debit payment method](https://stripe.com/docs/api/payment_methods/object#payment_method_object-sepa_debit)
+the following partial should be added:
+
+`app/views/checkouts/existing_payment/stripe/_sepa_debit.html.erb`
+
+```erb
+<% sepa_debit = stripe_payment_method.sepa_debit %>
+🏦 <%= sepa_debit.bank_code %> / <%= sepa_debit.branch_code %><br>
+IBAN: **** **** **** **** **** <%= sepa_debit.last4 %>
+```
+
 ### Custom webhooks
 
 You can also use [Stripe webhooks](https://stripe.com/docs/webhooks) to trigger

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -39,11 +39,13 @@ class SolidusStripe::IntentsController < Spree::BaseController
     when 'requires_capture'
       payment.pend! unless payment.pending?
       current_order.next!
+      add_payment_source_to_the_user_wallet(payment, intent)
       ensure_state_is(current_order, :confirm)
       ensure_state_is(payment, :pending)
     when 'succeeded'
       payment.completed! unless payment.completed?
       current_order.next!
+      add_payment_source_to_the_user_wallet(payment, intent)
       ensure_state_is(current_order, :confirm)
       ensure_state_is(payment, :completed)
     when 'canceled'
@@ -59,6 +61,14 @@ class SolidusStripe::IntentsController < Spree::BaseController
   end
 
   private
+
+  def add_payment_source_to_the_user_wallet(payment, intent)
+    return unless current_order.user
+    return if intent.setup_future_usage.blank?
+
+    payment.source.update(stripe_payment_method_id: intent.payment_method)
+    current_order.user.wallet.add payment.source
+  end
 
   def ensure_state_is(object, state)
     return if object.state.to_s == state.to_s

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -32,9 +32,9 @@ class SolidusStripe::IntentsController < Spree::BaseController
     case intent.status
     when 'requires_payment_method'
       ensure_state_is(current_order, :payment)
-      ensure_state_is(payment, :processing)
+      ensure_state_is(payment, :checkout)
     when 'requires_confirmation', 'requires_action', 'processing'
-      ensure_state_is(payment, :processing)
+      ensure_state_is(payment, :checkout)
       current_order.next!
     when 'requires_capture'
       payment.pend! unless payment.pending?

--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -5,6 +5,7 @@ require 'stripe'
 module SolidusStripe
   # @see https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=checkout#auth-and-capture
   # @see https://stripe.com/docs/charges/placing-a-hold
+  # @see https://guides.solidus.io/advanced-solidus/payments-and-refunds/#custom-payment-gateways
   #
   # ## About fractional amounts
   #

--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -29,6 +29,21 @@ module SolidusStripe
 
     attr_reader :client
 
+    # Authorizes a certain amount on the provided payment source.
+    #
+    # @see #purchase
+    def authorize(amount_in_cents, source, options = {})
+      stripe_payment_method = source.stripe_payment_method
+
+      payment_intent_options = options[:payment_intent_options].dup.to_h
+      payment_intent_options[:capture_method] = "manual"
+      payment_intent_options[:confirm] = true
+      payment_intent_options[:payment_method] = stripe_payment_method.id
+      payment_intent_options[:customer] = stripe_payment_method.customer
+
+      purchase(amount_in_cents, source, options.merge(payment_intent_options: payment_intent_options))
+    end
+
     # Captures a certain amount from a previously authorized transaction.
     #
     # @see https://stripe.com/docs/api/payment_intents/capture#capture_payment_intent

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -87,7 +87,7 @@ module SolidusStripe
               payment_method: self,
               response_code: intent.id,
               amount: order.total,
-            ).tap(&:started_processing!)
+            )
         end
       end
 

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -124,11 +124,12 @@ module SolidusStripe
       end
 
       def find_intent_for(payment)
+        return unless payment.transaction_id
+
         unless payment.payment_method == self
           raise ArgumentError, "this payment is from another payment_method"
         end
 
-        raise "missing payment intent id in response_code" if payment.response_code.blank?
         raise "bad payment intent id format" unless payment.response_code.start_with?('pi_')
 
         gateway.request { Stripe::PaymentIntent.retrieve(payment.response_code) }

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -104,20 +104,6 @@ module SolidusStripe
     end
 
     concerning :Payment do
-      def create_profile(payment)
-        payment_intent = find_intent_for(payment)
-
-        if payment_intent && payment_intent.customer.blank?
-          payment.payment_method.gateway.request do
-            payment_intent.customer = Stripe::Customer.new email: payment.order.email
-            payment_intent.customer.save
-            payment_intent.save
-          end
-        end
-
-        self
-      end
-
       def find_intent_for_order(order)
         payment = find_or_create_in_progress_payment_for(order)
         find_intent_for(payment) if payment
@@ -135,7 +121,8 @@ module SolidusStripe
       end
 
       def payment_profiles_supported?
-        true
+        # We actually support them, but not in the way expected by Solidus and its ActiveMerchant legacy.
+        false
       end
 
       def stripe_dashboard_url(payment)

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -7,24 +7,6 @@ module SolidusStripe
 
     validates :available_to_admin, inclusion: { in: [false] }
 
-    concerning :Actions do
-      def actions
-        %w[capture void credit]
-      end
-
-      def can_capture?(payment)
-        payment.pending?
-      end
-
-      def can_void?(payment)
-        payment.pending?
-      end
-
-      def can_credit?(payment)
-        payment.completed? && payment.credit_allowed > 0
-      end
-    end
-
     concerning :Configuration do
       def partial_name
         "stripe"
@@ -35,7 +17,7 @@ module SolidusStripe
       alias risky_partial_name partial_name
 
       def source_required?
-        false
+        true
       end
 
       def payment_source_class
@@ -85,6 +67,7 @@ module SolidusStripe
           order.payments
             .create!(
               payment_method: self,
+              source: payment_source_class.new(payment_method: self),
               response_code: intent.id,
               amount: order.total,
             )

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -4,8 +4,10 @@ module SolidusStripe
   class PaymentMethod < ::Spree::PaymentMethod
     preference :api_key, :string
     preference :publishable_key, :string
+    preference :setup_future_usage, :string, default: ''
 
     validates :available_to_admin, inclusion: { in: [false] }
+    validates :preferred_setup_future_usage, inclusion: { in: ['', 'on_session', 'off_session'] }
 
     concerning :Configuration do
       def partial_name
@@ -63,6 +65,7 @@ module SolidusStripe
               # The capture method should stay manual in order to
               # avoid capturing the money before the order is completed.
               capture_method: 'manual',
+              setup_future_usage: preferred_setup_future_usage.presence,
               customer: customer,
             })
           end

--- a/app/models/solidus_stripe/payment_source.rb
+++ b/app/models/solidus_stripe/payment_source.rb
@@ -7,7 +7,25 @@ module SolidusStripe
     def stripe_payment_method
       return if stripe_payment_method_id.blank?
 
-      @stripe_payment_method ||= payment_method.gateway.request { Stripe::PaymentMethod.retrieve(stripe_payment_method_id) }
+      @stripe_payment_method ||= payment_method.gateway.request do
+        Stripe::PaymentMethod.retrieve(stripe_payment_method_id)
+      end
+    end
+
+    def actions
+      %w[capture void credit]
+    end
+
+    def can_capture?(payment)
+      payment.pending?
+    end
+
+    def can_void?(payment)
+      payment.pending?
+    end
+
+    def can_credit?(payment)
+      payment.completed? && payment.credit_allowed > 0
     end
   end
 end

--- a/app/models/solidus_stripe/payment_source.rb
+++ b/app/models/solidus_stripe/payment_source.rb
@@ -4,5 +4,10 @@ require 'stripe'
 
 module SolidusStripe
   class PaymentSource < ::Spree::PaymentSource
+    def stripe_payment_method
+      return if stripe_payment_method_id.blank?
+
+      @stripe_payment_method ||= payment_method.gateway.request { Stripe::PaymentMethod.retrieve(stripe_payment_method_id) }
+    end
   end
 end

--- a/db/migrate/20230109183332_create_solidus_stripe_payment_sources.rb
+++ b/db/migrate/20230109183332_create_solidus_stripe_payment_sources.rb
@@ -2,6 +2,7 @@ class CreateSolidusStripePaymentSources < ActiveRecord::Migration[5.2]
   def change
     create_table :solidus_stripe_payment_sources do |t|
       t.integer :payment_method_id
+      t.string :stripe_payment_method_id
 
       t.timestamps
     end

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/_stripe.html.erb
@@ -1,0 +1,16 @@
+<%
+  stripe_payment_method = wallet_payment_source.payment_source.stripe_payment_method
+
+  # https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+  partial_base = "checkouts/existing_payment/stripe"
+  payment_type = stripe_payment_method.type
+
+  # Fallback on the default partial if a specialized partial is not available.
+  payment_type = 'default' if lookup_context.find_all("#{partial_base}/_#{payment_type}").none?
+%>
+
+<div>
+  <label>
+    <%= render "#{partial_base}/#{payment_type}", stripe_payment_method: stripe_payment_method %>
+  </label>
+</div>

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/stripe/_card.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/stripe/_card.html.erb
@@ -1,0 +1,8 @@
+<% card = stripe_payment_method.card %>
+<%#
+  Add credit card logos:
+  https://support.stripe.com/questions/where-to-find-logos-for-accepted-credit-card-types
+%>
+💳 <%= card.brand %>
+<span>**** **** **** <%= card.last4 %></span>
+(<%= t 'spree.expiration' %>: <%= card.exp_month %>/<%= card.exp_year %>)

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/stripe/_default.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/stripe/_default.html.erb
@@ -1,0 +1,7 @@
+<% logger.error(
+  %{Can't find a partial for payments with type #{payment_type} } +
+  %{please add a partial named "#{partial_base}/_#{payment_type}.html.erb".}
+) %>
+
+<%= stripe_payment_method.type.humanize %>
+(<%= time_ago_in_words Time.at(stripe_payment_method.created) %>)

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -22,5 +22,4 @@
     <!-- Display error/notification messages to your customers here -->
   </div>
 
-  <%= hidden_field_tag "order[payments_attributes][][stripe_intent_id]", intent.id %>
 </div>

--- a/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
+++ b/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
@@ -13,33 +13,6 @@ SolidusStripe.configure do |config|
   # config.webhook_signature_tolerance = 150
 end
 
-# Allow sending the payment id in the payment form and avoid the automatic
-# creation of an additional payment by Spree::PaymentCreate.
-#
-# We're providing a inline module to make it easier to remove the mokey-patch
-# once the upstream PR is merged and generally available.
-#
-# Fixes https://github.com/solidusio/solidus/issues/2680
-# Fixed by https://github.com/solidusio/solidus/pull/4909
-begin
-  module SolidusStripe::PaymentCreateWithExistingPayment
-    def build
-      # https://stackoverflow.com/a/62397649
-      if attributes[:stripe_intent_id]
-        @payment = order.payments.find_by!(response_code: attributes[:stripe_intent_id])
-      else
-        super
-      end
-    end
-  end
-
-  Rails.application.reloader.to_prepare do
-    Spree::PaymentCreate.prepend SolidusStripe::PaymentCreateWithExistingPayment
-  end
-
-  Spree::PermittedAttributes.checkout_payment_attributes.first[:payments_attributes] << :stripe_intent_id
-end
-
 if ENV['SOLIDUS_STRIPE_API_KEY']
   Rails.application.reloader.to_prepare do
     Spree::Config.static_model_preferences.add(

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -15,5 +15,6 @@ FactoryBot.define do
 
   factory :stripe_payment_source, class: 'SolidusStripe::PaymentSource' do
     association :payment_method, factory: :stripe_payment_method
+    stripe_payment_method_id { 'pm_123' }
   end
 end

--- a/spec/models/solidus_stripe/payment_source_spec.rb
+++ b/spec/models/solidus_stripe/payment_source_spec.rb
@@ -6,4 +6,20 @@ RSpec.describe SolidusStripe::PaymentSource, type: :model do
   it 'has a working factory' do
     expect(create(:stripe_payment_source)).to be_valid
   end
+
+  describe '#stripe_payment_method' do
+    it 'retrieves the Stripe::PaymentMethod object if the stripe_payment_method id is present' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: 'pm_123')
+      source = create(:stripe_payment_source, stripe_payment_method_id: 'pm_123')
+      allow(Stripe::PaymentMethod).to receive(:retrieve).with('pm_123').and_return(stripe_payment_method)
+
+      expect(source.stripe_payment_method).to eq(stripe_payment_method)
+    end
+
+    it 'returns nil if the stripe_payment_method id is missing' do
+      source = create(:stripe_payment_source, stripe_payment_method_id: nil)
+
+      expect(source.stripe_payment_method).to be_nil
+    end
+  end
 end

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'solidus_starter_frontend_helper'
+
+module SolidusStripe::CheckoutTestHelper
+  include SystemHelpers
+  def self.included(base)
+    base.include Devise::Test::IntegrationHelpers
+  end
+
+  def assign_guest_token(guest_token)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ActionDispatch::Cookies::SignedKeyRotatingCookieJar).tap do |allow_cookie_jar|
+      # Retrieve all other cookies from the original jar.
+      allow_cookie_jar.to receive(:[]).and_call_original
+      allow_cookie_jar.to receive(:[]).with(:guest_token).and_return(guest_token)
+    end
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  def fill_stripe_form(
+    number: 4242_4242_4242_4242, # rubocop:disable Style/NumericLiterals
+    expiry_month: 12,
+    expiry_year: Time.current.year + 1,
+    cvc: '123',
+    country: 'United States',
+    zip: '90210'
+  )
+    fill_in_stripe_cvc(cvc)
+    fill_in_stripe_expiry_date(year: expiry_year, month: expiry_month)
+    fill_in_stripe_card(number)
+    fill_in_stripe_country(country)
+    fill_in_stripe_zip(zip) if zip # not shown for every country
+  end
+
+  def fill_in_stripe_card(number)
+    fill_in_stripe_input 'number', with: number
+  end
+
+  def fill_in_stripe_expiry_date(year: nil, month: nil, date: nil)
+    date ||= begin
+      month = month.to_s.rjust(2, '0') unless month.is_a? String
+      year = year.to_s[2..3] unless year.is_a? String
+      "#{month}#{year}"
+    end
+
+    fill_in_stripe_input 'expiry', with: date.to_s[0..3]
+  end
+
+  def fill_in_stripe_cvc(cvc)
+    fill_in_stripe_input 'cvc', with: cvc.to_s[0..2].to_s
+  end
+
+  def fill_in_stripe_country(country_name)
+    using_wait_time(10) do
+      within_frame(find_stripe_iframe) do
+        find(%{select[name="country"]}).select(country_name)
+      end
+    end
+  end
+
+  def fill_in_stripe_zip(zip)
+    fill_in_stripe_input 'postalCode', with: zip
+  end
+
+  def fill_in_stripe_input(name, with:)
+    using_wait_time(10) do
+      within_frame(find_stripe_iframe) do
+        with.to_s.chars.each { find(%{input[name="#{name}"]}).send_keys(_1) }
+      end
+    end
+  end
+
+  # Assumes the presence of a #stripe_payment_method helper
+  def find_stripe_iframe
+    fieldset = find_payment_fieldset(stripe_payment_method.id)
+    expect(fieldset).to have_css('iframe') # trigger waiting if the frame is not yet there
+    fieldset.find("iframe")
+  end
+end

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -1,143 +1,89 @@
 # frozen_string_literal: true
 
 require 'solidus_stripe_spec_helper'
-require 'solidus_starter_frontend_helper'
 
 RSpec.describe "Checkout with Stripe", :js do
-  include Devise::Test::IntegrationHelpers
-  include SystemHelpers
+  include SolidusStripe::CheckoutTestHelper
 
   it "completes as a registered user" do
-    payment_method = create(:stripe_payment_method)
-    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: create(:user))
-
-    sign_in order.user
-    visit '/checkout/payment'
-    choose(option: payment_method.id)
+    create(:stripe_payment_method)
+    visit_payment_step(user: create(:user))
+    choose_new_stripe_payment
     fill_stripe_form
-    click_button("Save and Continue")
-    confirm_and_wait_for_the_success_page
-    order.reload
+    submit_payment
+    confirm_order
 
-    expect(page).to have_content("Your order has been processed successfully")
-    expect(page).to have_content(order.number)
-    expect(order).to be_complete
-    expect(order).to be_completed
-    expect(order.payments.first.amount).to eq(20)
-    expect(order.payments.pluck(:state)).to eq(['pending'])
-    expect(order.outstanding_balance.to_f).to eq(20)
+    order = Spree::Order.last
+    payment = order.payments.first
 
-    order.payments.first.capture!
-
-    expect(order.payments.reload.pluck(:state)).to eq(['completed'])
-    expect(order.outstanding_balance.to_f).to eq(0)
+    expect(Spree::Order.count).to eq(1)
+    expect_checkout_completion(order)
+    expect_payments_state(order, ['pending'])
+    payment.capture!
+    expect_payments_state(order, ['completed'], outstanding: 0)
+    expect(SolidusStripe::PaymentSource.count).to eq(1)
+    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_blank
   end
 
   it "completes as a guest" do
-    payment_method = create(:stripe_payment_method)
-    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: nil)
-    assign_guest_token order.guest_token
-
-    visit '/checkout/payment'
-    choose(option: payment_method.id)
+    create(:stripe_payment_method)
+    visit_payment_step(user: nil)
+    choose_new_stripe_payment
     fill_stripe_form
-    click_button("Save and Continue")
-    confirm_and_wait_for_the_success_page
-    order.reload
+    submit_payment
+    confirm_order
 
-    expect(page).to have_content("Your order has been processed successfully")
-    expect(page).to have_content(order.number)
-    expect(order).to be_complete
-    expect(order).to be_completed
-    expect(order.payments.first.amount).to eq(20)
-    expect(order.payments.pluck(:state)).to eq(['pending'])
-    expect(order.outstanding_balance.to_f).to eq(20)
-
+    order = Spree::Order.last
+    expect(Spree::Order.count).to eq(1)
+    expect_checkout_completion(order)
+    expect_payments_state(order, ['pending'], outstanding: order.total)
     order.payments.first.capture!
-
-    expect(order.payments.reload.pluck(:state)).to eq(['completed'])
-    expect(order.outstanding_balance.to_f).to eq(0)
+    expect_payments_state(order, ['completed'], outstanding: 0)
   end
 
   private
-
-  def assign_guest_token(guest_token)
-    # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(ActionDispatch::Cookies::SignedKeyRotatingCookieJar).tap do |allow_cookie_jar|
-      # Retrieve all other cookies from the original jar.
-      allow_cookie_jar.to receive(:[]).and_call_original
-      allow_cookie_jar.to receive(:[]).with(:guest_token).and_return(guest_token)
-    end
-    # rubocop:enable RSpec/AnyInstance
-  end
-
-  def confirm_and_wait_for_the_success_page
-    check "Agree to Terms of Service"
-    click_button("Place Order")
-    expect(page).to have_content("Your order has been processed successfully")
-  end
-
-  def fill_stripe_form(
-    number: 4242_4242_4242_4242, # rubocop:disable Style/NumericLiterals
-    expiry_month: 12,
-    expiry_year: Time.current.year + 1,
-    cvc: '123',
-    country: 'United States',
-    zip: '90210'
-  )
-    fill_in_stripe_cvc(cvc)
-    fill_in_stripe_expiry_date(year: expiry_year, month: expiry_month)
-    fill_in_stripe_card(number)
-    fill_in_stripe_country(country)
-    fill_in_stripe_zip(zip) if zip # not shown for every country
-  end
-
-  def fill_in_stripe_card(number)
-    fill_in_stripe_input 'number', with: number
-  end
-
-  def fill_in_stripe_expiry_date(year: nil, month: nil, date: nil)
-    date ||= begin
-      month = month.to_s.rjust(2, '0') unless month.is_a? String
-      year = year.to_s[2..3] unless year.is_a? String
-      "#{month}#{year}"
-    end
-
-    fill_in_stripe_input 'expiry', with: date.to_s[0..3]
-  end
-
-  def fill_in_stripe_cvc(cvc)
-    fill_in_stripe_input 'cvc', with: cvc.to_s[0..2].to_s
-  end
-
-  def fill_in_stripe_country(country_name)
-    using_wait_time(10) do
-      within_frame(find_stripe_iframe) do
-        find(%{select[name="country"]}).select(country_name)
-      end
-    end
-  end
-
-  def fill_in_stripe_zip(zip)
-    fill_in_stripe_input 'postalCode', with: zip
-  end
-
-  def fill_in_stripe_input(name, with:)
-    using_wait_time(10) do
-      within_frame(find_stripe_iframe) do
-        with.to_s.chars.each { find(%{input[name="#{name}"]}).send_keys(_1) }
-      end
-    end
-  end
 
   def stripe_payment_method
     # Memoize the payment method id to avoid fetching it multiple times
     @stripe_payment_method ||= SolidusStripe::PaymentMethod.first!
   end
 
-  def find_stripe_iframe
-    fieldset = find_payment_fieldset(stripe_payment_method.id)
-    expect(fieldset).to have_css('iframe') # trigger waiting if the frame is not yet there
-    fieldset.find("iframe")
+  def visit_payment_step(user: nil)
+    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
+
+    if user
+      sign_in order.user
+    else
+      assign_guest_token order.guest_token
+    end
+
+    visit '/checkout/payment'
+  end
+
+  def choose_new_stripe_payment
+    choose(option: stripe_payment_method.id)
+  end
+
+  def submit_payment
+    click_button("Save and Continue")
+  end
+
+  def confirm_order
+    check "Agree to Terms of Service"
+    click_button("Place Order")
+    expect(page).to have_content("Your order has been processed successfully")
+  end
+
+  def expect_checkout_completion(order = Spree::Order.last)
+    expect(page).to have_content("Your order has been processed successfully")
+    expect(page).to have_content(order.number)
+    expect(order).to be_complete
+    expect(order).to be_completed
+  end
+
+  def expect_payments_state(order, states, outstanding: order.total)
+    expect(order.payments.valid.sum(:amount)).to eq(order.total)
+    expect(order.payments.reload.pluck(:state)).to eq(states)
+    expect(order.outstanding_balance.to_f).to eq(outstanding)
   end
 end


### PR DESCRIPTION
## Summary

Adds wallet support by checking the `setup_future_usage` on the stripe payment intent, if future usage is allowed and the order has a user attached it will add the payment to the user wallet.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/1051/222721661-9e4753c0-13f5-48d7-a417-d6c35b056aae.png">

### Dependencies

- fixes #153 
- [x] address https://github.com/solidusio/solidus_stripe/pull/158#discussion_r1118436470
- [x] address https://github.com/solidusio/solidus_stripe/pull/158#discussion_r1118469701



## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
