### PR TITLE
bump min version of solidus_core dependency

### DIFF
--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'solidus_core', ['>= 2.3', '< 4']
+  spec.add_dependency 'solidus_core', ['>= 3.2', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.8'
 
   spec.add_dependency 'stripe', '~> 8.0'


### PR DESCRIPTION
## Summary

soldius Stripe makes use of Omnes gem and the Spree::Bus, both introduced in solidus 3.2.0. 
When trying to install solidus_stripe v5 With a version of solidus_core below 3.2, Omnes gem and `Spree::Bus` are not present but the current minimum version of solidus core for the solidus_stripe gem is 2.3.
I bumped the minimal required version of solidus core.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
