### PR TITLE
downgrade migration version

### DIFF
--- a/db/migrate/20230109183332_create_solidus_stripe_payment_sources.rb
+++ b/db/migrate/20230109183332_create_solidus_stripe_payment_sources.rb
@@ -1,4 +1,4 @@
-class CreateSolidusStripePaymentSources < ActiveRecord::Migration[7.0]
+class CreateSolidusStripePaymentSources < ActiveRecord::Migration[5.2]
   def change
     create_table :solidus_stripe_payment_sources do |t|
       t.integer :payment_method_id


### PR DESCRIPTION
## Summary

A migration should be able to run in an environment with the minimum rails version supported.
At the moment trying to install the solidus_strip v5 and running solidus_stripe migrations on an environment running  solidus core 3.0, for example, fails.

I guess [this PR](https://github.com/solidusio/solidus_stripe/pull/176) should be merged first. Then when we agree that we need solidus core 3.2 at minimum, we could say that 5.2 should be the the version number for this migration because Solidus core depends on a min rails version of 5.2 [here](https://github.com/solidusio/solidus/blob/v3.2.0/core/solidus_core.gemspec)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
