### PR TITLE
Make webhook testing more realistic and refactor its setup

### DIFF
--- a/spec/solidus_stripe_spec_helper.rb
+++ b/spec/solidus_stripe_spec_helper.rb
@@ -4,3 +4,7 @@ require 'stripe'
 require 'solidus_starter_frontend_helper'
 
 Dir["#{__dir__}/support/solidus_stripe/**/*.rb"].sort.each { |f| require f }
+
+RSpec.configure do |config|
+  config.include SolidusStripe::Webhook::RequestHelper, type: :webhook_request
+end

--- a/spec/support/solidus_stripe/webhook/data_fixtures.rb
+++ b/spec/support/solidus_stripe/webhook/data_fixtures.rb
@@ -1,31 +1,12 @@
 # frozen_string_literal: true
 
 module SolidusStripe
-  class WebhookFixtures
-    attr_reader :payload, :timestamp, :secret
-
-    def initialize(payload:, timestamp: Time.zone.now, secret: "whsec_123")
-      @payload = payload
-      @timestamp = timestamp
-      @secret = secret
-    end
-
-    def signature
-      @signature ||= Stripe::Webhook::Signature.compute_signature(timestamp, payload, secret)
-    end
-
-    def signature_header
-      @signature_header ||= Stripe::Webhook::Signature.generate_header(timestamp, signature)
-    end
-
-    class << self
-      def charge_succeeded
-        charge_succeeded_base.merge("webhook" => charge_succeeded_base)
-      end
-
-      private
-
-      def charge_succeeded_base
+  module Webhook
+    # Fixtures for Stripe webhook events represented as a Ruby hash.
+    #
+    # Consume with `SolidusStripe::Webhook::EventWithContextFactory.from_data`.
+    module DataFixtures
+      def self.charge_succeeded(with_webhook: true)
         {
           "id" => "evt_3MRUo1JvEPu9yc7w091rP2XV",
           "type" => "charge.succeeded",
@@ -116,7 +97,9 @@ module SolidusStripe
           "livemode" => false,
           "pending_webhooks" => 3,
           "request" => "req_CAHWxuQdLQukn0"
-        }
+        }.tap do |data|
+          data["webhook"] = charge_succeeded(with_webhook: false) if with_webhook
+        end
       end
     end
   end

--- a/spec/support/solidus_stripe/webhook/event_with_context_factory.rb
+++ b/spec/support/solidus_stripe/webhook/event_with_context_factory.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "solidus_stripe/webhook/event"
+require "stripe"
+
+module SolidusStripe
+  module Webhook
+    # Factory to create a webhook event along with its context.
+    #
+    # It allows to create Stripe webhook from different sources (hash, stripe
+    # object) in different representations (json, stripe event object, header).
+    #
+    # The context for a event is composed by the timestamp and its secret, which
+    # in turn affect the header representation.
+    class EventWithContextFactory
+      def self.from_data(data:, timestamp: Time.zone.now, secret: "whsec_123")
+        new(data: data, timestamp: timestamp, secret: secret)
+      end
+
+      def self.from_object(object:, type:, timestamp: Time.zone.now, secret: "whsec_123")
+        data_base = data_base(object, type)
+        data = data_base.merge("webhook" => data_base)
+        new(data: data, timestamp: timestamp, secret: secret)
+      end
+
+      def self.data_base(object, type)
+        {
+          "id" => "evt_3MRUo1JvEPu9yc7w091rP2XV",
+          "object" => "event",
+          "api_version" => "2022-11-15",
+          "created" => 1_674_022_050,
+          "data" => {
+            "object" => object.as_json
+          },
+          "livemode" => false,
+          "pending_webhooks" => 0,
+          "request" => {
+            "id" => "req_3MRUo1JvEPu9yc7w0",
+            "idempotency_key" => "idempotency_key"
+          },
+          "type" => type
+        }
+      end
+      private_class_method :data_base
+
+      attr_reader :data, :timestamp, :secret
+
+      def initialize(data:, timestamp: Time.zone.now, secret: "whsec_123")
+        @data = data
+        @timestamp = timestamp
+        @secret = secret
+      end
+
+      def stripe_object
+        @stripe_object ||= Stripe::Event.construct_from(data)
+      end
+
+      def json
+        @json ||= JSON.generate(data)
+      end
+
+      def signature_header(timestamp: self.timestamp)
+        @signature_header ||= Stripe::Webhook::Signature.generate_header(timestamp, signature)
+      end
+
+      def signature
+        @signature ||= Stripe::Webhook::Signature.compute_signature(timestamp, json, secret)
+      end
+    end
+  end
+end

--- a/spec/support/solidus_stripe/webhook/request_helper.rb
+++ b/spec/support/solidus_stripe/webhook/request_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  module Webhook
+    # Helpers to simulate incoming Stripe webhook from request specs.
+    #
+    # It's a lightweight alternative to configuring `stripe-cli` in the automated tests.
+    module RequestHelper
+      # @param context [SolidusStripe::Webhook::EventWithContextFactory]
+      # @param timestamp [Time] It allows to override the timestamp in the context
+      #   to simulate an invalid request.
+      def webhook_request(context, timestamp: context.timestamp)
+        stub_webhook_endpoint_secret(context.secret)
+
+        post "/solidus_stripe/webhooks",
+          params: context.json,
+          headers: { webhook_signature_header_key => webhook_signature_header(context, timestamp: timestamp) }
+      end
+
+      private
+
+      def webhook_signature_header_key
+        SolidusStripe::WebhooksController::SIGNATURE_HEADER
+      end
+
+      def webhook_signature_header(context, timestamp:)
+        context.signature_header(timestamp: timestamp)
+      end
+
+      def stub_webhook_endpoint_secret(secret)
+        allow(Rails.application.credentials).to receive(:solidus_stripe)
+          .and_return({ webhook_endpoint_secret: secret })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

We're splitting the webhook testing helpers into three parts:

- `EventWithContextFactory` can create a stripe event from different sources (hash, Stripe object) and in different representations (JSON, `Stripe::Event` instance, header value in a request).

- `HashFixtures` hardcodes a Hash representation of a Stripe event. We can use it with `EventWithContextFactory.from_hash` to consume it.

- `RequestHelper` provides helper methods for request specs to simulate webhook requests from an instance of `EventWithContextFactory`.

We leverage creating a Stripe webhook event from a Stripe object on request specs. The creation of the Stripe object will call Stripe's API, giving us more assurance that we're working with actual data; plus, it allows us to create events from objects created from within the library code (i.e., payment intents). Although the generated scenario won't be 100% real, as we still need to wrap the object with boilerplate data, it's a good compromise against using [`stripe-cli`](https://stripe.com/docs/webhooks/test) on the test suite, which would require a complex setup mainly on CI.

Conversely, we leverage the Hash fixture for unit tests on `SolidusStripe::Webhook::Event` to avoid performing requests there.

This PR will pave the way for #179 and all the other webhook events we're going to implement.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
