### PR TITLE
Add support for SetupIntents and skipping the confirm step for PaymentIntents

### DIFF
--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -126,6 +126,7 @@ module SolidusStripe
     end
 
     # Refunds the provided amount on a previously captured transaction.
+    # TODO: check this method params twice.
     def credit(amount_in_cents, _source, payment_intent_id, options = {})
       payment = options[:originator].payment
       currency = payment.currency

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class PaymentIntent < ApplicationRecord
+    belongs_to :order, class_name: 'Spree::Order'
+
+    def stripe_payment_intent(payment_method)
+      payment_method.gateway.request do
+        Stripe::PaymentIntent.retrieve(stripe_payment_intent_id)
+      end
+    end
+  end
+end

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -6,6 +6,7 @@ module SolidusStripe
     preference :publishable_key, :string
     preference :setup_future_usage, :string, default: ''
     preference :stripe_intents_flow, :string, default: 'setup'
+    preference :skip_confirmation_for_payment_intent, :boolean, default: true
 
     validates :available_to_admin, inclusion: { in: [false] }
     validates :preferred_setup_future_usage, inclusion: { in: ['', 'on_session', 'off_session'] }
@@ -150,6 +151,11 @@ module SolidusStripe
 
         intent
       end
+    end
+
+    def skip_confirm_step?
+      preferred_stripe_intents_flow == 'payment' &&
+        preferred_skip_confirmation_for_payment_intent
     end
 
     def payment_profiles_supported?

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class SetupIntent < Spree::Base
+    belongs_to :order, class_name: 'Spree::Order'
+
+    def stripe_setup_intent(payment_method)
+      payment_method.gateway.request do
+        Stripe::SetupIntent.retrieve(stripe_setup_intent_id)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 SolidusStripe::Engine.routes.draw do
   scope ':payment_method_id' do
     get :payment_confirmation, controller: :intents
+    get :setup_confirmation, controller: :intents
   end
   resources :webhooks, only: :create, format: false
 end

--- a/db/migrate/20230303154931_create_solidus_stripe_setup_intent.rb
+++ b/db/migrate/20230303154931_create_solidus_stripe_setup_intent.rb
@@ -1,0 +1,10 @@
+class CreateSolidusStripeSetupIntent < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solidus_stripe_setup_intents do |t|
+      t.string :stripe_setup_intent_id
+      t.references :order, null: false, foreign_key: { to_table: :spree_orders }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230306105520_create_solidus_stripe_payment_intents.rb
+++ b/db/migrate/20230306105520_create_solidus_stripe_payment_intents.rb
@@ -1,0 +1,10 @@
+class CreateSolidusStripePaymentIntents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solidus_stripe_payment_intents do |t|
+      t.string :stripe_payment_intent_id
+      t.references :order, null: false, foreign_key: { to_table: :spree_orders }
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
     solidusPaymentMethodId: String,
     emailAddress: String,
     returnUrl: String,
+    flow: String,
     // For now we don't have a controller to interact with
     // so we fallback on acquiring the selector.
     paymentFormSelector: String,
@@ -54,15 +55,29 @@ export default class extends Controller {
   }
 
   confirmIntent() {
-    return this.stripe.confirmPayment({
-      elements: this.elements,
-      confirmParams: {
-        // NOTE: `.confirmPayment()` will redirect the whole page and come back to
-        //       the `return_url` unless an immediate error gets in the way.
-        return_url: this.returnUrlValue,
-        receipt_email: this.emailAddressValue,
-      },
-    })
+    if (this.flowValue == 'payment') {
+      return this.stripe.confirmPayment({
+        elements: this.elements,
+        confirmParams: {
+          // NOTE: `.confirmPayment()` will redirect the whole page and come back to
+          //       the `return_url` unless an immediate error gets in the way.
+          return_url: this.returnUrlValue,
+          receipt_email: this.emailAddressValue,
+        },
+      })
+    } else if (this.flowValue == 'setup') {
+      return this.stripe.confirmSetup({
+        elements: this.elements,
+        confirmParams: {
+          // NOTE: `.confirmPayment()` will redirect the whole page and come back to
+          //       the `return_url` unless an immediate error gets in the way.
+          return_url: this.returnUrlValue,
+          // receipt_email: this.emailAddressValue, # TODO: Add support for this when using the intent
+        },
+      })
+    } else {
+      throw new Error("flowValue should be either 'payment' or 'setup'.")
+    }
   }
 
   setupPaymentElement() {

--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
@@ -42,15 +42,7 @@ export default class extends Controller {
 
     this.setLoading(true)
 
-    const { error } = await this.stripe.confirmPayment({
-      elements: this.elements,
-      confirmParams: {
-        // NOTE: `.confirmPayment()` will redirect the whole page and come back to
-        //       the `return_url` unless an immediate error gets in the way.
-        return_url: this.returnUrlValue,
-        receipt_email: this.emailAddressValue,
-      },
-    })
+    const { error } = await this.confirmIntent()
 
     if (error.type === 'card_error' || error.type === 'validation_error') {
       this.messageTarget.textContent = error.message
@@ -59,6 +51,18 @@ export default class extends Controller {
     }
 
     this.setLoading(false)
+  }
+
+  confirmIntent() {
+    return this.stripe.confirmPayment({
+      elements: this.elements,
+      confirmParams: {
+        // NOTE: `.confirmPayment()` will redirect the whole page and come back to
+        //       the `return_url` unless an immediate error gets in the way.
+        return_url: this.returnUrlValue,
+        receipt_email: this.emailAddressValue,
+      },
+    })
   }
 
   setupPaymentElement() {

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -4,21 +4,21 @@
 
 <div
   class="solidus-stripe-payment"
-  data-controller="solidus-stripe-payment"
-  data-solidus-stripe-payment-client-secret-value="<%= intent.client_secret %>"
-  data-solidus-stripe-payment-publishable-key-value="<%= payment_method.preferred_publishable_key %>"
-  data-solidus-stripe-payment-solidus-payment-method-id-value="<%= payment_method.id %>"
-  data-solidus-stripe-payment-email-address-value="<%= current_order.email %>"
-  data-solidus-stripe-payment-return-url-value="<%= solidus_stripe.payment_confirmation_url(payment_method) %>"
-  data-solidus-stripe-payment-payment-form-selector-value="#checkout_form_payment"
-  data-action="submit@window->solidus-stripe-payment#handleSubmit"
+  data-controller="solidus-stripe-intent"
+  data-solidus-stripe-intent-client-secret-value="<%= intent.client_secret %>"
+  data-solidus-stripe-intent-publishable-key-value="<%= payment_method.preferred_publishable_key %>"
+  data-solidus-stripe-intent-solidus-payment-method-id-value="<%= payment_method.id %>"
+  data-solidus-stripe-intent-email-address-value="<%= current_order.email %>"
+  data-solidus-stripe-intent-return-url-value="<%= solidus_stripe.payment_confirmation_url(payment_method) %>"
+  data-solidus-stripe-intent-payment-form-selector-value="#checkout_form_payment"
+  data-action="submit@window->solidus-stripe-intent#handleSubmit"
 >
-  <div data-solidus-stripe-payment-target="paymentElement">
+  <div data-solidus-stripe-intent-target="paymentElement">
     <!-- Elements will create form elements here -->
     <em><%= t('solidus_stripe.loading') %></em>
   </div>
 
-  <div data-solidus-stripe-payment-target="message">
+  <div data-solidus-stripe-intent-target="message">
     <!-- Display error/notification messages to your customers here -->
   </div>
 

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -1,6 +1,12 @@
 <script src="https://js.stripe.com/v3/"></script>
 
-<% intent = payment_method.find_intent_for_order(current_order) %>
+<% if payment_method.preferred_stripe_intents_flow == 'setup' %>
+  <% intent = payment_method.find_or_create_setup_intent_for_order(current_order) %>
+  <% return_url = solidus_stripe.setup_confirmation_url(payment_method) %>
+<% else %>
+  <% intent = payment_method.find_intent_for_order(current_order) %>
+  <% return_url = solidus_stripe.payment_confirmation_url(payment_method) %>
+<% end %>
 
 <div
   class="solidus-stripe-payment"
@@ -9,8 +15,9 @@
   data-solidus-stripe-intent-publishable-key-value="<%= payment_method.preferred_publishable_key %>"
   data-solidus-stripe-intent-solidus-payment-method-id-value="<%= payment_method.id %>"
   data-solidus-stripe-intent-email-address-value="<%= current_order.email %>"
-  data-solidus-stripe-intent-return-url-value="<%= solidus_stripe.payment_confirmation_url(payment_method) %>"
+  data-solidus-stripe-intent-return-url-value="<%= return_url %>"
   data-solidus-stripe-intent-payment-form-selector-value="#checkout_form_payment"
+  data-solidus-stripe-intent-flow-value="<%= payment_method.preferred_stripe_intents_flow %>"
   data-action="submit@window->solidus-stripe-intent#handleSubmit"
 >
   <div data-solidus-stripe-intent-target="paymentElement">
@@ -21,5 +28,4 @@
   <div data-solidus-stripe-intent-target="message">
     <!-- Display error/notification messages to your customers here -->
   </div>
-
 </div>

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -3,9 +3,10 @@
 <% if payment_method.preferred_stripe_intents_flow == 'setup' %>
   <% intent = payment_method.find_or_create_setup_intent_for_order(current_order) %>
   <% return_url = solidus_stripe.setup_confirmation_url(payment_method) %>
-<% else %>
-  <% intent = payment_method.find_intent_for_order(current_order) %>
+<% elsif payment_method.preferred_stripe_intents_flow == 'payment' %>
+  <% intent = payment_method.find_or_create_payment_intent_for_order(current_order) %>
   <% return_url = solidus_stripe.payment_confirmation_url(payment_method) %>
+<% else raise 'what the heck!' %>
 <% end %>
 
 <div

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -29,4 +29,14 @@
   <div data-solidus-stripe-intent-target="message">
     <!-- Display error/notification messages to your customers here -->
   </div>
+
+  <% if payment_method.skip_confirm_step? %>
+    <div class="terms_and_conditions">
+      <%= render 'checkouts/terms_and_conditions' %>
+      <label>
+        <%= check_box_tag :accept_terms_and_conditions, 'accepted', false, required: true, id: nil %>
+        <%= t('spree.agree_to_terms_of_service') %>
+      </label>
+    </div>
+  <% end %>
 </div>

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -5,12 +5,34 @@ require 'solidus_stripe_spec_helper'
 RSpec.describe "Checkout with Stripe", :js do
   include SolidusStripe::CheckoutTestHelper
 
-  it "completes as a registered user" do
-    create(:stripe_payment_method)
+  it "completes as a registered user using setup intents" do
+    create(:stripe_payment_method, preferred_stripe_intents_flow: 'setup')
     visit_payment_step(user: create(:user))
     choose_new_stripe_payment
     fill_stripe_form
     submit_payment
+    expect_payments_state(Spree::Order.last, ['checkout'])
+    confirm_order
+
+    order = Spree::Order.last
+    payment = order.payments.first
+
+    expect(Spree::Order.count).to eq(1)
+    expect_checkout_completion(order)
+    expect_payments_state(order, ['pending'])
+    payment.capture!
+    expect_payments_state(order, ['completed'], outstanding: 0)
+    expect(SolidusStripe::PaymentSource.count).to eq(1)
+    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_present
+  end
+
+  it "completes as a registered user using payment intents" do
+    create(:stripe_payment_method, preferred_stripe_intents_flow: 'payment')
+    visit_payment_step(user: create(:user))
+    choose_new_stripe_payment
+    fill_stripe_form
+    submit_payment
+    expect_payments_state(Spree::Order.last, ['pending'])
     confirm_order
 
     order = Spree::Order.last
@@ -25,12 +47,13 @@ RSpec.describe "Checkout with Stripe", :js do
     expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_blank
   end
 
-  it "completes as a guest" do
-    create(:stripe_payment_method)
+  it "completes as a guest using payment intents" do
+    create(:stripe_payment_method, preferred_stripe_intents_flow: 'payment')
     visit_payment_step(user: nil)
     choose_new_stripe_payment
     fill_stripe_form
     submit_payment
+    expect_payments_state(Spree::Order.last, ['pending'])
     confirm_order
 
     order = Spree::Order.last
@@ -41,13 +64,14 @@ RSpec.describe "Checkout with Stripe", :js do
     expect_payments_state(order, ['completed'], outstanding: 0)
   end
 
-  it "completes as a registered user and reuses the payment" do
+  it "completes as a registered user and reuses the payment using payment intents" do
     # Pay for the first time
-    create(:stripe_payment_method, preferred_setup_future_usage: 'off_session')
+    create(:stripe_payment_method, preferred_setup_future_usage: 'off_session', preferred_stripe_intents_flow: 'payment')
     visit_payment_step(user: create(:user))
     choose_new_stripe_payment
     fill_stripe_form
     submit_payment
+    expect_payments_state(Spree::Order.last, ['pending'])
     confirm_order
 
     order = Spree::Order.last
@@ -67,6 +91,7 @@ RSpec.describe "Checkout with Stripe", :js do
     visit_payment_step(user: user)
     find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
     submit_payment
+    expect_payments_state(Spree::Order.last, ['invalid', 'checkout'])
     confirm_order
 
     order = Spree::Order.last
@@ -108,6 +133,7 @@ RSpec.describe "Checkout with Stripe", :js do
 
   def submit_payment
     click_button("Save and Continue")
+    expect(page).to have_content("Agree to Terms of Service")
   end
 
   def confirm_order

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Checkout with Stripe", :js do
     visit_payment_step(user: user)
     find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
     submit_payment
-    expect_payments_state(Spree::Order.last, ['invalid', 'checkout'])
+    expect_payments_state(Spree::Order.last, ['checkout'])
     confirm_order
 
     order = Spree::Order.last
@@ -138,12 +138,12 @@ RSpec.describe "Checkout with Stripe", :js do
     expect(Spree::Order.count).to eq(2)
     expect(order.user).to eq(user)
     expect_checkout_completion(order)
-    expect_payments_state(order, ['invalid', 'pending'])
+    expect_payments_state(order, ['pending'])
     expect(order.payments.valid.count).to eq(1)
     payment.capture!
-    expect_payments_state(order, ['invalid', 'completed'], outstanding: 0)
-    expect(SolidusStripe::PaymentSource.count).to eq(2)
-    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).not_to be_present
+    expect_payments_state(order, ['completed'], outstanding: 0)
+    expect(SolidusStripe::PaymentSource.count).to eq(1)
+    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_present
     expect(payment.source).to eq(reusable_source)
   end
 


### PR DESCRIPTION
## Summary

- Allows to use SetupIntents in the payment step and avoid the premature authorization on credit cards
- Allows to skip the confirm step when using PaymentIntents and have the checkout end with the payment
- Stores the payment intent id on a model attached to the order instead of using an "in progress" payment that gets created at the payment step

Checkout specs covering the happy path for each case have been added, this should avoid regression and demonstrate the expected flows.

## Authors

@kennyadsl @elia @rainerdema @waiting-for-dev 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
