### PR TITLE
Add a basic codecov config to show commit status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,21 @@ orbs:
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
 
-commands:
-  run-specs-with-starter-frontend:
+jobs:
+  run-specs:
+    parameters:
+      database:
+        type: string
+        default: postgres
+      ruby:
+        type: string
+        default: "3.2"
+      coverage:
+        type: boolean
+        default: false
+    executor:
+      name: solidusio_extensions/<< parameters.database >>
+      ruby_version: << parameters.ruby >>
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -20,13 +33,13 @@ commands:
             sudo apt-get update
             sudo apt-get install -yq libvips-dev
       - run:
-          name: 'Update Rubygems'
+          name: "Update Rubygems"
           command: |
             sudo gem update --system --no-document
             gem install bundler --no-document
             gem environment path
       - run:
-          name: 'Store tool versions'
+          name: "Store tool versions"
           command: |
             rm -rf /tmp/.tool-versions
             ruby -v >> /tmp/.tool-versions
@@ -38,11 +51,11 @@ commands:
             - solidus-stripe-gems-v1-{{ checksum "/tmp/.tool-versions" }}
             - solidus-stripe-gems-v1-
       - run:
-          name: 'Install gems'
+          name: "Install gems"
           command: |
             bundle install
       - run:
-          name: 'Install dummy app'
+          name: "Install dummy app"
           command: bin/dummy-app
           environment:
             FRONTEND: starter
@@ -52,29 +65,15 @@ commands:
           paths:
             - /home/circleci/.rubygems
       - run:
-          name: 'Runs specs'
+          name: "Runs specs"
           command: |
+            <<#parameters.coverage>>export COVERAGE=true<</parameters.coverage>>
             bin/rspec --format progress --format RspecJunitFormatter --out "$PWD/test-results/results.xml"
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: /home/circleci/project/dummy-app/tmp/capybara/
           destination: capybara
-
-jobs:
-  run-specs:
-    parameters:
-      database:
-        type: string
-        default: postgres
-      ruby:
-        type: string
-        default: '3.2'
-    executor:
-      name: solidusio_extensions/<< parameters.database >>
-      ruby_version: << parameters.ruby >>
-    steps:
-      - run-specs-with-starter-frontend
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:
@@ -91,10 +90,11 @@ workflows:
   build:
     jobs:
       - run-specs:
-          name: 'run-specs-ruby-<<matrix.ruby>>-db-<<matrix.database>>'
+          name: "run-specs-ruby-<<matrix.ruby>>-db-<<matrix.database>>"
           context: stripe-test-credentials
           matrix:
             parameters:
-              ruby: ['3.2'] # TODO: ['3.2', '3.1', '3.0']
-              database: ['sqlite'] # TODO: ['mysql', 'sqlite', 'postgres']
+              ruby: ["3.2"] # TODO: ['3.2', '3.1', '3.0']
+              database: ["sqlite"] # TODO: ['mysql', 'sqlite', 'postgres']
+              coverage: [true]
       - lint-code

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,7 @@ gem 'timeout'
 gem 'listen'
 
 gem 'activestorage'
+
+gem 'codecov', require: false
+gem 'rspec_junit_formatter', require: false
+gem 'simplecov', '~> 0.22', require: false

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -6,7 +6,7 @@ extension_name="solidus_stripe"
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {
-  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- "$@"
+  ruby -rbundler -e'Bundler.with_unbundled_env{system({"BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES"=>"1"},*ARGV)}' -- "$@"
 }
 
 # "sqlite" is set by the ORB extension instead of "sqlite3",
@@ -26,6 +26,14 @@ if [ ! -d "dummy-app" ]; then
 fi
 
 cd ./dummy-app
+
+# Coverage
+echo "require_relative '../../coverage.rb' if ENV['COVERAGE']" >> config/boot.rb
+echo "gem 'simplecov', '~> 0.22', require: false" >> Gemfile
+echo "gem 'rspec_junit_formatter', require: false" >> Gemfile
+echo "gem 'codecov', require: false" >> Gemfile
+unbundled bundle install
+
 unbundled bundle add solidus --github solidusio/solidus --branch "${SOLIDUS_BRANCH:-master}" --version '> 0.a'
 unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"

--- a/bin/rspec
+++ b/bin/rspec
@@ -6,4 +6,4 @@ system(
 ) or abort(File.read("tmp/rspec-sync.log"))
 
 Dir.chdir "dummy-app/"
-exec "rspec", *ARGV
+exec "bundle", "exec", "rspec", *ARGV

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto

--- a/coverage.rb
+++ b/coverage.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'coverage'
+require 'simplecov'
+
+SimpleCov.root File.expand_path(__dir__)
+
+if ENV['CODECOV_TOKEN']
+  require 'codecov'
+
+  class FixedCodeCovFormatter
+    # The `file_network` method will run a wildcard from inside the current dir
+    # instead of inside the SimpleCov root.
+    def format(result)
+      Dir.chdir(SimpleCov.root) do
+        SimpleCov::Formatter::Codecov.new.format(result)
+      end
+    end
+  end
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+    FixedCodeCovFormatter,
+    SimpleCov.formatter,
+  ])
+else
+  warn "Provide a CODECOV_TOKEN environment variable to enable Codecov uploads"
+end
+
+def (SimpleCov::ResultAdapter).call(result)
+  result = result.transform_keys do |path|
+    template_path = path.sub(
+      "#{SimpleCov.root}/dummy-app/",
+      "#{SimpleCov.root}/lib/generators/solidus_stripe/install/templates/"
+    )
+    File.exist?(template_path) ? template_path : path
+  end
+  result.each do |path, coverage|
+    next unless path.end_with?('.erb')
+
+    # Remove the extra trailing lines added by ERB
+    coverage[:lines] = coverage[:lines][...File.read(path).lines.size]
+  end
+  result
+end
+
+SimpleCov.start do
+  root __dir__
+  enable_coverage_for_eval
+  add_filter %r{dummy-app/(db|config|spec|tmp)/}
+  track_files "#{SimpleCov.root}/{dummy-app,lib,app}/**/*.{rb,erb}}"
+end


### PR DESCRIPTION
## Summary

Fixes #211 

Use coverage to understand what major areas or edge cases should be tested.

Correctly translates paths from the dummy-app to the templates dir, so that sources are visible in the CodeCov UI.

ERB look off from time to time, but it's not clear if a line is lost in translation or it's a ruby+ERB bug.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
