### PR TITLE
Simplify generated code to configure the payment method preferences

### DIFF
--- a/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
+++ b/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
@@ -14,13 +14,11 @@ SolidusStripe.configure do |config|
 end
 
 if ENV['SOLIDUS_STRIPE_API_KEY']
-  Rails.application.reloader.to_prepare do
-    Spree::Config.static_model_preferences.add(
-      SolidusStripe::PaymentMethod,
-      'solidus_stripe_env_credentials',
-      api_key: ENV.fetch('SOLIDUS_STRIPE_API_KEY'),
-      publishable_key: ENV.fetch('SOLIDUS_STRIPE_PUBLISHABLE_KEY'),
-      test_mode: ENV.fetch('SOLIDUS_STRIPE_API_KEY').start_with?('sk_test_'),
-    )
-  end
+  Spree::Config.static_model_preferences.add(
+    'SolidusStripe::PaymentMethod',
+    'solidus_stripe_env_credentials',
+    api_key: ENV.fetch('SOLIDUS_STRIPE_API_KEY'),
+    publishable_key: ENV.fetch('SOLIDUS_STRIPE_PUBLISHABLE_KEY'),
+    test_mode: ENV.fetch('SOLIDUS_STRIPE_API_KEY').start_with?('sk_test_'),
+  )
 end


### PR DESCRIPTION
## Summary

There's no longer the need to call `.to_prepare`, as the issue has been
fixed upstream:

- v3.3: https://github.com/solidusio/solidus/pull/4858
- v3.2: https://github.com/solidusio/solidus/pull/4939
- v3.1: https://github.com/solidusio/solidus/pull/4967

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
