### PR TITLE
Add setup intents support to stripe dashboard link helper

### DIFF
--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -47,7 +47,7 @@ class SolidusStripe::IntentsController < Spree::BaseController
     current_order.next!
     add_setup_intent_to_the_user_wallet(intent, payment)
 
-    flash[:notice] = t(".setup_intent_status.#{intent.status}")
+    flash[:notice] = t(".intent_status.#{intent.status}")
     redirect_to main_app.checkout_state_path(current_order.state)
   end
 
@@ -91,7 +91,7 @@ class SolidusStripe::IntentsController < Spree::BaseController
       current_order.complete!
       redirect_to main_app.token_order_path(current_order, current_order.guest_token)
     else
-      flash[:notice] = t(".intent_status.#{intent.status}")
+      flash[:notice] = t(".payment_intent_status.#{intent.status}")
       redirect_to main_app.checkout_state_path(current_order.state)
     end
   end

--- a/app/views/spree/admin/payments/source_views/_stripe.html.erb
+++ b/app/views/spree/admin/payments/source_views/_stripe.html.erb
@@ -3,14 +3,11 @@
 
   <div class="row">
     <div class="col-4">
-      <dl>
-        <dt><%= SolidusStripe::PaymentSource.human_attribute_name(:stripe_payment_intent_id) %>:</dt>
-        <dd><%= link_to(
-          payment.transaction_id,
-          payment.payment_method.stripe_dashboard_url(payment),
-          target: :_blank,
-        ) %></dd>
-      </dl>
+      <%= link_to(
+        "Open in the Stripe dashboard ↗",
+        payment.payment_method.stripe_dashboard_url(payment),
+        target: :_blank,
+      ) %>
     </div>
   </div>
 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
 
     intents:
       payment_confirmation:
-        intent_status:
+        intent_status: &intent_status
           canceled: 'Your payment has been canceled.'
           processing: 'Your payment is processing.'
           requires_action: 'Some action is needed on your payment before proceeding.'
@@ -15,6 +15,9 @@ en:
           requires_confirmation: 'Please confirm the payment in order to proceed.'
           requires_payment_method: 'Your payment was not successful, please try again.'
           succeeded: 'Payment succeeded!'
+      setup_confirmation:
+        intent_status:
+          <<: *intent_status
 
   activerecord:
     models:
@@ -25,4 +28,4 @@ en:
         solidus_stripe/payment_method:
           attributes:
             available_to_admin:
-              inclusion: "is not allowed for the Stripe payment method"
+              inclusion: 'is not allowed for the Stripe payment method'

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -18,18 +18,56 @@ RSpec.describe SolidusStripe::PaymentMethod do
   end
 
   describe '#stripe_dashboard_url' do
-    it 'generates a dashboard link' do
-      payment_method = build(:stripe_payment_method, preferred_test_mode: false)
-      payment = build(:payment, response_code: 'pi_123')
+    context 'when the payment has a transaction_id' do
+      it 'generates a dashboard link' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+        payment = build(:payment, response_code: 'pi_123')
 
-      expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/payments/pi_123")
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/payments/pi_123")
+      end
+
+      it 'supports test mode' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
+        payment = build(:payment, response_code: 'pi_123')
+
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/payments/pi_123")
+      end
     end
 
-    it 'supports test mode' do
-      payment_method = build(:stripe_payment_method, preferred_test_mode: true)
-      payment = build(:payment, response_code: 'pi_123')
+    context 'when the order has a payment intent' do
+      it 'generates a dashboard link' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+        payment = build(:payment, response_code: nil)
+        _intent = SolidusStripe::PaymentIntent.create(order: payment.order, stripe_payment_intent_id: 'pi_123')
 
-      expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/payments/pi_123")
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/payments/pi_123")
+      end
+
+      it 'supports test mode' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
+        payment = build(:payment, response_code: nil)
+        _intent = SolidusStripe::PaymentIntent.create(order: payment.order, stripe_payment_intent_id: 'pi_123')
+
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/payments/pi_123")
+      end
+    end
+
+    context 'when the order has a setup intent' do
+      it 'generates a dashboard link' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+        payment = build(:payment, response_code: nil)
+        _intent = SolidusStripe::SetupIntent.create(order: payment.order, stripe_setup_intent_id: 'seti_123')
+
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/setup_intents/seti_123")
+      end
+
+      it 'supports test mode' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
+        payment = build(:payment, response_code: nil)
+        _intent = SolidusStripe::SetupIntent.create(order: payment.order, stripe_setup_intent_id: 'seti_123')
+
+        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/setup_intents/seti_123")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

We added payment and setup intents classes attached to the order and we should provide dashboard links in accordance to it.
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
