### PR TITLE
Make webhook endpoint specific to the payment method instance

### DIFF
--- a/app/controllers/solidus_stripe/webhooks_controller.rb
+++ b/app/controllers/solidus_stripe/webhooks_controller.rb
@@ -12,7 +12,8 @@ module SolidusStripe
     respond_to :json
 
     def create
-      event = Webhook::Event.from_request(payload: request.body.read, signature_header: signature_header)
+      event = Webhook::Event.from_request(payload: request.body.read, signature_header: signature_header,
+        slug: params[:slug])
       return head(:bad_request) unless event
 
       Spree::Bus.publish(event) && head(:ok)

--- a/app/models/solidus_stripe/webhook_endpoint.rb
+++ b/app/models/solidus_stripe/webhook_endpoint.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  # Represents a webhook endpoint for a {SolidusStripe::PaymentMethod}.
+  #
+  # A Stripe webhook endpoint is a URL that Stripe will send events to. A store
+  # could have multiple Stripe payment methods (e.g., a marketplace), so we need
+  # to differentiate which one a webhook request targets.
+  #
+  # This model associates a slug with a payment method. The slug is appended
+  # to the endpoint URL (`.../webhooks/:slug`) so that we can fetch the
+  # correct payment method from the database and bind it to the generated
+  # `Spree::Bus` event.
+  #
+  # We use a slug instead of the payment method ID to be resilient to
+  # database changes and to avoid guessing about valid endpoint URLs.
+  class WebhookEndpoint < ::Spree::Base
+    belongs_to :payment_method,
+      class_name: 'SolidusStripe::PaymentMethod'
+
+    # @api private
+    def self.generate_slug
+      SecureRandom.hex(16).then do |slug|
+        exists?(slug: slug) ? generate_slug : slug
+      end
+    end
+
+    # Finds the payment method associated with the given slug.
+    #
+    # @param slug [String]
+    # @raise [ActiveRecord::RecordNotFound] if no payment method is found
+    # @return [SolidusStripe::PaymentMethod]
+    def self.payment_method(slug)
+      find_by!(slug: slug).payment_method
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ SolidusStripe::Engine.routes.draw do
     get :payment_confirmation, controller: :intents
     get :setup_confirmation, controller: :intents
   end
-  resources :webhooks, only: :create, format: false
+  post '/webhooks/:slug', format: false, to: 'webhooks#create'
 end

--- a/db/migrate/20230308122414_create_solidus_stripe_webhook_endpoints.rb
+++ b/db/migrate/20230308122414_create_solidus_stripe_webhook_endpoints.rb
@@ -1,0 +1,10 @@
+class CreateSolidusStripeWebhookEndpoints < ActiveRecord::Migration[5.2]
+  def change
+    create_table :solidus_stripe_webhook_endpoints do |t|
+      t.references :payment_method, null: false, foreign_key: { to_table: :spree_payment_methods }
+      t.string :slug, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
+++ b/lib/generators/solidus_stripe/install/templates/config/initializers/solidus_stripe.rb
@@ -20,5 +20,6 @@ if ENV['SOLIDUS_STRIPE_API_KEY']
     api_key: ENV.fetch('SOLIDUS_STRIPE_API_KEY'),
     publishable_key: ENV.fetch('SOLIDUS_STRIPE_PUBLISHABLE_KEY'),
     test_mode: ENV.fetch('SOLIDUS_STRIPE_API_KEY').start_with?('sk_test_'),
+    webhook_endpoint_signing_secret: ENV.fetch('SOLIDUS_STRIPE_WEBHOOK_SIGNING_SECRET')
   )
 end

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -7,8 +7,12 @@ FactoryBot.define do
     available_to_admin { false }
     preferences {
       {
-        api_key: ENV['SOLIDUS_STRIPE_API_KEY'] || "sk_dummy_#{SecureRandom.hex(24)}",
-        publishable_key: ENV['SOLIDUS_STRIPE_PUBLISHABLE_KEY'] || "pk_dummy_#{SecureRandom.hex(24)}",
+        api_key: ENV['SOLIDUS_STRIPE_API_KEY'] ||
+          "sk_dummy_#{SecureRandom.hex(24)}",
+        publishable_key: ENV['SOLIDUS_STRIPE_PUBLISHABLE_KEY'] ||
+          "pk_dummy_#{SecureRandom.hex(24)}",
+        webhook_endpoint_signing_secret: ENV['SOLIDUS_STRIPE_WEBHOOK_SIGNING_SECRET'] ||
+          "whsec_dummy_#{SecureRandom.hex(32)}"
       }
     }
   end
@@ -28,5 +32,10 @@ FactoryBot.define do
     association :order
     association :payment_method, factory: :stripe_payment_method
     stripe_intent_id { "seti_#{SecureRandom.uuid.delete('-')}" }
+  end
+
+  factory :stripe_webhook_endpoint, class: 'SolidusStripe::WebhookEndpoint' do
+    association :payment_method, factory: :stripe_payment_method
+    slug { SecureRandom.hex(16) }
   end
 end

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe SolidusStripe::PaymentMethod do
     ).to be(true)
   end
 
+  describe 'Callbacks' do
+    describe 'after_create' do
+      it 'creates a webhook endpoint' do
+        payment_method = create(:stripe_payment_method)
+
+        expect(payment_method.webhook_endpoint).to be_present
+      end
+    end
+  end
+
   describe '#intent_id_for_payment' do
     context 'when the payment has a transaction_id' do
       it 'fetches the payment intent id from the response code' do

--- a/spec/models/solidus_stripe/webhook_endpoint_spec.rb
+++ b/spec/models/solidus_stripe/webhook_endpoint_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'solidus_stripe_spec_helper'
+
+RSpec.describe SolidusStripe::WebhookEndpoint do
+  describe '.generate_slug' do
+    it 'generates a random hex string' do
+      expect(described_class.generate_slug).to match(/^[0-9a-f]{32}$/)
+    end
+
+    it 'generates a unique slug' do
+      slug = SecureRandom.hex(16)
+      create(:stripe_webhook_endpoint, slug: slug)
+      allow(described_class).to receive(:generate_slug).and_return(slug).and_call_original
+
+      expect(described_class.generate_slug).not_to eq(slug)
+    end
+  end
+
+  describe '.payment_method' do
+    it 'finds the payment method associated with the given slug' do
+      payment_method = create(:stripe_payment_method)
+      described_class.create!(payment_method: payment_method, slug: 'foo')
+
+      expect(described_class.payment_method('foo')).to eq(payment_method)
+    end
+
+    it 'raises an error if no payment method is found' do
+      expect { described_class.payment_method('invalid') }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/requests/solidus_stripe/webhooks_controller_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe SolidusStripe::WebhooksController, type: [:request, :webhook_requ
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.from_object(
         object: payment_intent,
-        type: "payment_intent.created"
+        type: "payment_intent.created",
+        payment_method: stripe
       )
     end
 

--- a/spec/support/solidus_stripe/webhook/request_helper.rb
+++ b/spec/support/solidus_stripe/webhook/request_helper.rb
@@ -7,12 +7,13 @@ module SolidusStripe
     # It's a lightweight alternative to configuring `stripe-cli` in the automated tests.
     module RequestHelper
       # @param context [SolidusStripe::Webhook::EventWithContextFactory]
+      # @param payment_method [SolidusStripe::PaymentMethod]
       # @param timestamp [Time] It allows to override the timestamp in the context
       #   to simulate an invalid request.
+      # @param slug [String] It allows to override the slug in the payment
+      #   method to simulate an invalid request.
       def webhook_request(context, timestamp: context.timestamp)
-        stub_webhook_endpoint_secret(context.secret)
-
-        post "/solidus_stripe/webhooks",
+        post "/solidus_stripe/webhooks/#{context.slug}",
           params: context.json,
           headers: { webhook_signature_header_key => webhook_signature_header(context, timestamp: timestamp) }
       end
@@ -25,11 +26,6 @@ module SolidusStripe
 
       def webhook_signature_header(context, timestamp:)
         context.signature_header(timestamp: timestamp)
-      end
-
-      def stub_webhook_endpoint_secret(secret)
-        allow(Rails.application.credentials).to receive(:solidus_stripe)
-          .and_return({ webhook_endpoint_secret: secret })
       end
     end
   end


### PR DESCRIPTION
## Summary

The work on this PR allows registering different webhook endpoints for each instance of Solidus Stripe payment methods. That's a scenario that can help support marketplaces.

We're automatically generating a slug when a Stripe payment method is created. Users must use that in the default `/solidus_stripe/webhooks/:slug` endpoint to get the specific URL for a payment method instance. The slug is stored on a separate `SolidusStripe::WebhookEndpoint` model with a one-to-one relationship with `SolidusStripe::PaymentMethod`. There's no single entry point to create payment methods, so we must use an ActiveRecord callback to persist the slug. We're using a slug and not the payment method id to be resilient against database changes and to avoid guessing about valid endpoint URLs.

As a consequence of bringing the webhook endpoint URL to the payment method instance, we're also moving the configuration of the webhook signing secret from a generic Rails credential to a payment method preference.

We're now providing the slug to the `SolidusStripe::Event.from_request` method to retrieve the associated payment method and its signing secret. The payment method is now bundled as part of the created Omnes event so that subscribers can act differently in every case. For the test setup, the payment method is now part of the `EventWithContextFactory` instances.

Closes #161

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
