### PR TITLE
Refactor intent related methods out of PaymentMethod

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,11 @@ Style/TrailingUnderscoreVariable:
 RSpec/DescribeClass:
   Exclude:
     - spec/system/**/*
+
+Rails/NotNullColumn:
+  Exclude:
+    - db/migrate/20230310152615_add_payment_method_reference_to_stripe_intents.rb
+
+Layout/LineLength:
+  Exclude:
+    - db/migrate/**/*

--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -8,7 +8,11 @@ class SolidusStripe::IntentsController < Spree::BaseController
   before_action :load_payment_method
 
   def setup_confirmation
-    intent = @payment_method.find_setup_intent_for_order(current_order)
+    intent_class = SolidusStripe::SetupIntent
+    intent = intent_class.find_by!(
+      payment_method: @payment_method,
+      order: current_order,
+    ).stripe_intent
 
     if params[:setup_intent] != intent.id
       raise "The setup intent id doesn't match"
@@ -52,7 +56,11 @@ class SolidusStripe::IntentsController < Spree::BaseController
   end
 
   def payment_confirmation
-    intent = @payment_method.find_payment_intent_for_order(current_order)
+    intent_class = SolidusStripe::PaymentIntent
+    intent = intent_class.find_by!(
+      payment_method: @payment_method,
+      order: current_order,
+    ).stripe_intent
 
     if params[:payment_intent] != intent.id
       raise "The payment intent id doesn't match"

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -3,10 +3,34 @@
 module SolidusStripe
   class PaymentIntent < ApplicationRecord
     belongs_to :order, class_name: 'Spree::Order'
+    belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    def stripe_payment_intent(payment_method)
+    before_create :create_stripe_intent, unless: :stripe_payment_intent_id?
+
+    def stripe_intent
       payment_method.gateway.request do
         Stripe::PaymentIntent.retrieve(stripe_payment_intent_id)
+      end
+    end
+
+    def create_stripe_intent
+      customer = payment_method.customer_for(order.user) || payment_method.customer_for_order(order)
+
+      self.stripe_payment_intent_id = payment_method.gateway.request do
+        Stripe::PaymentIntent.create({
+          amount: payment_method.gateway.to_stripe_amount(
+            order.display_total.money.fractional,
+            order.currency,
+          ),
+          currency: order.currency,
+
+          # The capture method should stay manual in order to
+          # avoid capturing the money before the order is completed.
+          capture_method: 'manual',
+          setup_future_usage: payment_method.preferred_setup_future_usage.presence,
+          customer: customer,
+          metadata: { solidus_order_number: order.number },
+        }).id
       end
     end
   end

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -5,18 +5,18 @@ module SolidusStripe
     belongs_to :order, class_name: 'Spree::Order'
     belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    before_create :create_stripe_intent, unless: :stripe_payment_intent_id?
+    before_create :create_stripe_intent, unless: :stripe_intent_id?
 
     def stripe_intent
       payment_method.gateway.request do
-        Stripe::PaymentIntent.retrieve(stripe_payment_intent_id)
+        Stripe::PaymentIntent.retrieve(stripe_intent_id)
       end
     end
 
     def create_stripe_intent
       customer = payment_method.customer_for(order)
 
-      self.stripe_payment_intent_id = payment_method.gateway.request do
+      self.stripe_intent_id = payment_method.gateway.request do
         Stripe::PaymentIntent.create({
           amount: payment_method.gateway.to_stripe_amount(
             order.display_total.money.fractional,

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -14,7 +14,7 @@ module SolidusStripe
     end
 
     def create_stripe_intent
-      customer = payment_method.customer_for(order.user) || payment_method.customer_for_order(order)
+      customer = payment_method.customer_for(order)
 
       self.stripe_payment_intent_id = payment_method.gateway.request do
         Stripe::PaymentIntent.create({

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -163,13 +163,18 @@ module SolidusStripe
       false
     end
 
-    def stripe_dashboard_url(payment)
-      path_prefix = '/test' if preferred_test_mode
+    # Fetches the payment intent when available, falls back on the setup intent associated to the order.
+    def self.intent_id_for_payment(payment)
+      return unless payment
 
-      intent_id =
-        payment.transaction_id ||
+      payment.transaction_id || (
         SolidusStripe::PaymentIntent.where(order: payment.order).pick(:stripe_payment_intent_id) ||
         SolidusStripe::SetupIntent.where(order: payment.order).pick(:stripe_setup_intent_id)
+      )
+    end
+
+    def stripe_dashboard_url(intent_id)
+      path_prefix = '/test' if preferred_test_mode
 
       case intent_id
       when /^pi_/

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -91,13 +91,16 @@ module SolidusStripe
     end
 
     # Fetches the payment intent when available, falls back on the setup intent associated to the order.
+    # @api private
+    # TODO: re-evaluate the need for this and think of ways to always go throught the intent classes.
     def self.intent_id_for_payment(payment)
       return unless payment
 
-      payment.transaction_id || (
-        SolidusStripe::PaymentIntent.where(order: payment.order, payment_method: payment.payment_method)&.pick(:stripe_payment_intent_id) ||
-        SolidusStripe::SetupIntent.where(order: payment.order, payment_method: payment.payment_method)&.pick(:stripe_setup_intent_id)
-      )
+      payment.transaction_id || SolidusStripe::PaymentIntent.where(
+        order: payment.order, payment_method: payment.payment_method
+      )&.pick(:stripe_intent_id) || SolidusStripe::SetupIntent.where(
+        order: payment.order, payment_method: payment.payment_method
+      )&.pick(:stripe_intent_id)
     end
 
     def stripe_dashboard_url(intent_id)

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -82,77 +82,6 @@ module SolidusStripe
       end
     end
 
-    concerning :SetupIntents do
-      def find_or_create_setup_intent_for_order(order)
-        find_setup_intent_for_order(order) || create_setup_intent_for_order(order)
-      end
-
-      def find_setup_intent_for_order(order)
-        SolidusStripe::SetupIntent
-          .find_by(order: order) # TODO: order.setup_intent (?)
-          &.stripe_setup_intent(self)
-      end
-
-      def create_setup_intent_for_order(order)
-        customer = customer_for(order.user) || customer_for_order(order)
-
-        intent = gateway.request do
-          Stripe::SetupIntent.create({
-            customer: customer,
-            usage: 'off_session', # TODO: use the payment method's preference
-            metadata: { solidus_order_number: order.number },
-          })
-        end
-
-        SolidusStripe::SetupIntent.create!(
-          order: order,
-          stripe_setup_intent_id: intent.id,
-        )
-
-        intent
-      end
-    end
-
-    concerning :PaymentIntents do
-      def find_or_create_payment_intent_for_order(order)
-        find_payment_intent_for_order(order) || create_payment_intent_for_order(order)
-      end
-
-      def find_payment_intent_for_order(order)
-        SolidusStripe::PaymentIntent
-          .find_by(order: order)
-          &.stripe_payment_intent(self)
-      end
-
-      def create_payment_intent_for_order(order)
-        customer = customer_for(order.user) || customer_for_order(order)
-
-        intent = gateway.request do
-          Stripe::PaymentIntent.create({
-            amount: gateway.to_stripe_amount(
-              order.display_total.money.fractional,
-              order.currency,
-            ),
-            currency: order.currency,
-
-            # The capture method should stay manual in order to
-            # avoid capturing the money before the order is completed.
-            capture_method: 'manual',
-            setup_future_usage: preferred_setup_future_usage.presence,
-            customer: customer,
-            metadata: { solidus_order_number: order.number },
-          })
-        end
-
-        SolidusStripe::PaymentIntent.create!(
-          order: order,
-          stripe_payment_intent_id: intent.id,
-        )
-
-        intent
-      end
-    end
-
     def skip_confirm_step?
       preferred_stripe_intents_flow == 'payment' &&
         preferred_skip_confirmation_for_payment_intent
@@ -168,8 +97,8 @@ module SolidusStripe
       return unless payment
 
       payment.transaction_id || (
-        SolidusStripe::PaymentIntent.where(order: payment.order).pick(:stripe_payment_intent_id) ||
-        SolidusStripe::SetupIntent.where(order: payment.order).pick(:stripe_setup_intent_id)
+        SolidusStripe::PaymentIntent.where(order: payment.order, payment_method: payment.payment_method)&.pick(:stripe_payment_intent_id) ||
+        SolidusStripe::SetupIntent.where(order: payment.order, payment_method: payment.payment_method)&.pick(:stripe_setup_intent_id)
       )
     end
 

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -14,7 +14,7 @@ module SolidusStripe
     end
 
     def create_stripe_intent
-      customer = payment_method.customer_for(order.user) || payment_method.customer_for_order(order)
+      customer = payment_method.customer_for(order)
 
       self.stripe_setup_intent_id = payment_method.gateway.request do
         Stripe::SetupIntent.create({

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -5,7 +5,15 @@ module SolidusStripe
     belongs_to :order, class_name: 'Spree::Order'
     belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    before_create :create_stripe_intent, unless: :stripe_intent_id?
+    def self.retrieve_or_create_stripe_intent(payment_method:, order:)
+      instance = find_or_initialize_by(payment_method: payment_method, order: order)
+
+      if instance.stripe_intent_id
+        instance.stripe_intent
+      else
+        instance.create_stripe_intent.tap { instance.update!(stripe_intent_id: _1.id) }
+      end
+    end
 
     def stripe_intent
       payment_method.gateway.request do
@@ -16,12 +24,12 @@ module SolidusStripe
     def create_stripe_intent
       customer = payment_method.customer_for(order)
 
-      self.stripe_intent_id = payment_method.gateway.request do
+      payment_method.gateway.request do
         Stripe::SetupIntent.create({
           customer: customer,
           usage: 'off_session', # TODO: use the payment method's preference
           metadata: { solidus_order_number: order.number },
-        }).id
+        })
       end
     end
   end

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -5,18 +5,18 @@ module SolidusStripe
     belongs_to :order, class_name: 'Spree::Order'
     belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    before_create :create_stripe_intent, unless: :stripe_setup_intent_id?
+    before_create :create_stripe_intent, unless: :stripe_intent_id?
 
     def stripe_intent
       payment_method.gateway.request do
-        Stripe::SetupIntent.retrieve(stripe_setup_intent_id)
+        Stripe::SetupIntent.retrieve(stripe_intent_id)
       end
     end
 
     def create_stripe_intent
       customer = payment_method.customer_for(order)
 
-      self.stripe_setup_intent_id = payment_method.gateway.request do
+      self.stripe_intent_id = payment_method.gateway.request do
         Stripe::SetupIntent.create({
           customer: customer,
           usage: 'off_session', # TODO: use the payment method's preference

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -3,10 +3,25 @@
 module SolidusStripe
   class SetupIntent < Spree::Base
     belongs_to :order, class_name: 'Spree::Order'
+    belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    def stripe_setup_intent(payment_method)
+    before_create :create_stripe_intent, unless: :stripe_setup_intent_id?
+
+    def stripe_intent
       payment_method.gateway.request do
         Stripe::SetupIntent.retrieve(stripe_setup_intent_id)
+      end
+    end
+
+    def create_stripe_intent
+      customer = payment_method.customer_for(order.user) || payment_method.customer_for_order(order)
+
+      self.stripe_setup_intent_id = payment_method.gateway.request do
+        Stripe::SetupIntent.create({
+          customer: customer,
+          usage: 'off_session', # TODO: use the payment method's preference
+          metadata: { solidus_order_number: order.number },
+        }).id
       end
     end
   end

--- a/app/views/spree/admin/payments/source_views/_stripe.html.erb
+++ b/app/views/spree/admin/payments/source_views/_stripe.html.erb
@@ -1,3 +1,5 @@
+<%= intent_id = SolidusStripe::PaymentMethod.intent_id_for_payment(payment) %>
+
 <fieldset data-hook="credit_card">
   <legend align="center"><%= SolidusStripe::PaymentSource.model_name.human %></legend>
 
@@ -5,7 +7,7 @@
     <div class="col-4">
       <%= link_to(
         "Open in the Stripe dashboard ↗",
-        payment.payment_method.stripe_dashboard_url(payment),
+        payment.payment_method.stripe_dashboard_url(intent_id),
         target: :_blank,
       ) %>
     </div>

--- a/db/migrate/20230310152615_add_payment_method_reference_to_stripe_intents.rb
+++ b/db/migrate/20230310152615_add_payment_method_reference_to_stripe_intents.rb
@@ -1,0 +1,6 @@
+class AddPaymentMethodReferenceToStripeIntents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :solidus_stripe_setup_intents, :payment_method, null: false, foreign_key: { to_table: :spree_payment_methods }
+    add_reference :solidus_stripe_payment_intents, :payment_method, null: false, foreign_key: { to_table: :spree_payment_methods }
+  end
+end

--- a/db/migrate/20230310171444_normalize_stripe_intent_id_attributes.rb
+++ b/db/migrate/20230310171444_normalize_stripe_intent_id_attributes.rb
@@ -1,0 +1,6 @@
+class NormalizeStripeIntentIdAttributes < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :solidus_stripe_payment_intents, :stripe_payment_intent_id, :stripe_intent_id
+    rename_column :solidus_stripe_setup_intents, :stripe_setup_intent_id, :stripe_intent_id
+  end
+end

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -10,10 +10,10 @@
 <% end %>
 
 <%# TODO: See if we can move the intent creation out of the view %>
-<% intent = intent_class.find_or_create_by(
+<% intent = intent_class.retrieve_or_create_stripe_intent(
   payment_method: payment_method,
   order: current_order,
-).stripe_intent %>
+) %>
 
 <div
   class="solidus-stripe-payment"

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -1,13 +1,19 @@
 <script src="https://js.stripe.com/v3/"></script>
 
 <% if payment_method.preferred_stripe_intents_flow == 'setup' %>
-  <% intent = payment_method.find_or_create_setup_intent_for_order(current_order) %>
+  <% intent_class = SolidusStripe::SetupIntent %>
   <% return_url = solidus_stripe.setup_confirmation_url(payment_method) %>
 <% elsif payment_method.preferred_stripe_intents_flow == 'payment' %>
-  <% intent = payment_method.find_or_create_payment_intent_for_order(current_order) %>
+  <% intent_class = SolidusStripe::PaymentIntent %>
   <% return_url = solidus_stripe.payment_confirmation_url(payment_method) %>
 <% else raise 'what the heck!' %>
 <% end %>
+
+<%# TODO: See if we can move the intent creation out of the view %>
+<% intent = intent_class.find_or_create_by(
+  payment_method: payment_method,
+  order: current_order,
+).stripe_intent %>
 
 <div
   class="solidus-stripe-payment"

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -15,6 +15,6 @@ FactoryBot.define do
 
   factory :stripe_payment_source, class: 'SolidusStripe::PaymentSource' do
     association :payment_method, factory: :stripe_payment_method
-    stripe_payment_method_id { 'pm_123' }
+    stripe_payment_method_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
 end

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -21,12 +21,12 @@ FactoryBot.define do
   factory :stripe_payment_intent, class: 'SolidusStripe::PaymentIntent' do
     association :order
     association :payment_method, factory: :stripe_payment_method
-    stripe_payment_intent_id { "pm_#{SecureRandom.uuid.delete('-')}" }
+    stripe_intent_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
 
   factory :stripe_setup_intent, class: 'SolidusStripe::SetupIntent' do
     association :order
     association :payment_method, factory: :stripe_payment_method
-    stripe_setup_intent_id { "seti_#{SecureRandom.uuid.delete('-')}" }
+    stripe_intent_id { "seti_#{SecureRandom.uuid.delete('-')}" }
   end
 end

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -17,4 +17,14 @@ FactoryBot.define do
     association :payment_method, factory: :stripe_payment_method
     stripe_payment_method_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
+
+  factory :stripe_payment_intent, class: 'SolidusStripe::PaymentIntent' do
+    association :order
+    stripe_payment_intent_id { "pm_#{SecureRandom.uuid.delete('-')}" }
+  end
+
+  factory :stripe_setup_intent, class: 'SolidusStripe::SetupIntent' do
+    association :order
+    stripe_setup_intent_id { "seti_#{SecureRandom.uuid.delete('-')}" }
+  end
 end

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -20,11 +20,13 @@ FactoryBot.define do
 
   factory :stripe_payment_intent, class: 'SolidusStripe::PaymentIntent' do
     association :order
+    association :payment_method, factory: :stripe_payment_method
     stripe_payment_intent_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
 
   factory :stripe_setup_intent, class: 'SolidusStripe::SetupIntent' do
     association :order
+    association :payment_method, factory: :stripe_payment_method
     stripe_setup_intent_id { "seti_#{SecureRandom.uuid.delete('-')}" }
   end
 end

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
 
     context 'when the order has a payment intent' do
       it 'fetches the payment intent id' do
-        intent = create(:stripe_payment_intent, stripe_payment_intent_id: 'pi_123')
+        intent = create(:stripe_payment_intent, stripe_intent_id: 'pi_123')
         payment = build(:payment, response_code: nil, payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
@@ -44,7 +44,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
       end
 
       it 'fetches the setup intent id when the payment intent is not available' do
-        intent = create(:stripe_setup_intent, stripe_setup_intent_id: 'seti_123')
+        intent = create(:stripe_setup_intent, stripe_intent_id: 'seti_123')
         payment = build(:payment, response_code: nil, payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("seti_123")

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -17,57 +17,80 @@ RSpec.describe SolidusStripe::PaymentMethod do
     ).to be(true)
   end
 
-  describe '#stripe_dashboard_url' do
+  describe '#intent_id_for_payment' do
     context 'when the payment has a transaction_id' do
-      it 'generates a dashboard link' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+      it 'fetches the payment intent id from the response code' do
         payment = build(:payment, response_code: 'pi_123')
 
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/payments/pi_123")
-      end
-
-      it 'supports test mode' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
-        payment = build(:payment, response_code: 'pi_123')
-
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/payments/pi_123")
+        expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
       end
     end
 
     context 'when the order has a payment intent' do
-      it 'generates a dashboard link' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
-        payment = build(:payment, response_code: nil)
-        _intent = SolidusStripe::PaymentIntent.create(order: payment.order, stripe_payment_intent_id: 'pi_123')
+      it 'fetches the payment intent id' do
+        intent = create(:stripe_payment_intent, stripe_payment_intent_id: 'pi_123')
+        payment = build(:payment, response_code: nil, order: intent.order)
 
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/payments/pi_123")
-      end
-
-      it 'supports test mode' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
-        payment = build(:payment, response_code: nil)
-        _intent = SolidusStripe::PaymentIntent.create(order: payment.order, stripe_payment_intent_id: 'pi_123')
-
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/payments/pi_123")
+        expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
       end
     end
 
     context 'when the order has a setup intent' do
+      it 'fetches the setup intent id' do
+        intent = create(:stripe_setup_intent)
+        payment = build(:payment, response_code: "pi_123", order: intent.order)
+
+        expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
+      end
+
+      it 'fetches the setup intent id when the payment intent is not available' do
+        intent = create(:stripe_setup_intent, stripe_setup_intent_id: 'seti_123')
+        payment = build(:payment, response_code: nil, order: intent.order)
+
+        expect(described_class.intent_id_for_payment(payment)).to eq("seti_123")
+      end
+    end
+
+    it 'returns nil without a payment' do
+      expect(described_class.intent_id_for_payment(nil)).to eq(nil)
+    end
+  end
+
+  describe '#stripe_dashboard_url' do
+    context 'with a payment intent id' do
       it 'generates a dashboard link' do
         payment_method = build(:stripe_payment_method, preferred_test_mode: false)
-        payment = build(:payment, response_code: nil)
-        _intent = SolidusStripe::SetupIntent.create(order: payment.order, stripe_setup_intent_id: 'seti_123')
 
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/setup_intents/seti_123")
+        expect(payment_method.stripe_dashboard_url('pi_123')).to eq("https://dashboard.stripe.com/payments/pi_123")
       end
 
       it 'supports test mode' do
         payment_method = build(:stripe_payment_method, preferred_test_mode: true)
-        payment = build(:payment, response_code: nil)
-        _intent = SolidusStripe::SetupIntent.create(order: payment.order, stripe_setup_intent_id: 'seti_123')
 
-        expect(payment_method.stripe_dashboard_url(payment)).to eq("https://dashboard.stripe.com/test/setup_intents/seti_123")
+        expect(payment_method.stripe_dashboard_url('pi_123')).to eq("https://dashboard.stripe.com/test/payments/pi_123")
       end
+    end
+
+    context 'with a setup intent id' do
+      it 'generates a dashboard link' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+
+        expect(payment_method.stripe_dashboard_url('seti_123')).to eq("https://dashboard.stripe.com/setup_intents/seti_123")
+      end
+
+      it 'supports test mode' do
+        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
+
+        expect(payment_method.stripe_dashboard_url('seti_123')).to eq("https://dashboard.stripe.com/test/setup_intents/seti_123")
+      end
+    end
+
+    it 'returns nil with anything else' do
+      payment_method = build(:stripe_payment_method)
+
+      expect(payment_method.stripe_dashboard_url(Object.new)).to eq(nil)
+      expect(payment_method.stripe_dashboard_url('')).to eq(nil)
+      expect(payment_method.stripe_dashboard_url(123)).to eq(nil)
     end
   end
 end

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
     context 'when the order has a payment intent' do
       it 'fetches the payment intent id' do
         intent = create(:stripe_payment_intent, stripe_payment_intent_id: 'pi_123')
-        payment = build(:payment, response_code: nil, order: intent.order)
+        payment = build(:payment, response_code: nil, payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
       end
@@ -38,14 +38,14 @@ RSpec.describe SolidusStripe::PaymentMethod do
     context 'when the order has a setup intent' do
       it 'fetches the setup intent id' do
         intent = create(:stripe_setup_intent)
-        payment = build(:payment, response_code: "pi_123", order: intent.order)
+        payment = build(:payment, response_code: "pi_123", payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
       end
 
       it 'fetches the setup intent id when the payment intent is not available' do
         intent = create(:stripe_setup_intent, stripe_setup_intent_id: 'seti_123')
-        payment = build(:payment, response_code: nil, order: intent.order)
+        payment = build(:payment, response_code: nil, payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("seti_123")
       end


### PR DESCRIPTION
## Summary

We already had _concerns_ grouping methods in the PaymentMethod class, now we took the time to actually move them to their legitimate place in the intent classes.

This is to be considered a preliminary step toward encapsulating the strategy into a class.

Ref #210 

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
