### PR TITLE
Add test coverage for integration with Solidus Starter Frontend

### DIFF
--- a/app/controllers/solidus_stripe/intents_controller.rb
+++ b/app/controllers/solidus_stripe/intents_controller.rb
@@ -99,7 +99,7 @@ class SolidusStripe::IntentsController < Spree::BaseController
       current_order.complete!
       redirect_to main_app.token_order_path(current_order, current_order.guest_token)
     else
-      flash[:notice] = t(".payment_intent_status.#{intent.status}")
+      flash[:notice] = t(".intent_status.#{intent.status}")
       redirect_to main_app.checkout_state_path(current_order.state)
     end
   end

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -26,7 +26,7 @@ module SolidusStripe
       payment_method.gateway.request do
         Stripe::SetupIntent.create({
           customer: customer,
-          usage: 'off_session', # TODO: use the payment method's preference
+          usage: payment_method.preferred_setup_future_usage.presence,
           metadata: { solidus_order_number: order.number },
         }.merge(stripe_intent_options))
       end

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -8,7 +8,12 @@ module SolidusStripe::CheckoutTestHelper
     base.include Devise::Test::IntegrationHelpers
   end
 
-  def assign_guest_token(guest_token)
+  # Setup methods
+  #
+  # These are methods that are used specifically for setting up the
+  # environment for testing.
+
+  def assigns_guest_token(guest_token)
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(ActionDispatch::Cookies::SignedKeyRotatingCookieJar).tap do |allow_cookie_jar|
       # Retrieve all other cookies from the original jar.
@@ -18,63 +23,303 @@ module SolidusStripe::CheckoutTestHelper
     # rubocop:enable RSpec/AnyInstance
   end
 
-  def fill_stripe_form(
+  def creates_payment_method(
+    intents_flow: 'setup',
+    setup_future_usage: 'off_session',
+    skip_confirmation: false
+  )
+    @payment_method = create(:stripe_payment_method,
+      preferred_stripe_intents_flow: intents_flow,
+      preferred_setup_future_usage: setup_future_usage,
+      preferred_skip_confirmation_for_payment_intent: skip_confirmation)
+  end
+
+  def payment_method
+    # Memoize the payment method id to avoid fetching it multiple times
+    @payment_method ||= SolidusStripe::PaymentMethod.first!
+  end
+
+  def captures_last_valid_payment
+    payment = Spree::Payment.valid.last
+    payment.capture!
+    expect(payment.payment_method.type).to eq('SolidusStripe::PaymentMethod')
+    intent = payment.payment_method.gateway.request do
+      Stripe::PaymentIntent.retrieve(payment.response_code)
+    end
+    expect(intent.status).to eq('succeeded')
+  end
+
+  # Stripe form methods
+  #
+  # These are methods that are used specifically for interacting with
+  # the Stripe payment form.
+
+  def fills_stripe_form(
     number: 4242_4242_4242_4242, # rubocop:disable Style/NumericLiterals
     expiry_month: 12,
     expiry_year: Time.current.year + 1,
+    date: nil,
     cvc: '123',
     country: 'United States',
     zip: '90210'
   )
-    fill_in_stripe_cvc(cvc)
-    fill_in_stripe_expiry_date(year: expiry_year, month: expiry_month)
-    fill_in_stripe_card(number)
-    fill_in_stripe_country(country)
-    fill_in_stripe_zip(zip) if zip # not shown for every country
+    fills_in_stripe_cvc(cvc)
+    fills_in_stripe_expiry_date(year: expiry_year, month: expiry_month, date: date)
+    fills_in_stripe_card(number)
+    fills_in_stripe_country(country)
+    fills_in_stripe_zip(zip) if zip # not shown for every country
   end
 
-  def fill_in_stripe_card(number)
-    fill_in_stripe_input 'number', with: number
+  def fills_in_stripe_card(number)
+    fills_in_stripe_input 'number', with: number
   end
 
-  def fill_in_stripe_expiry_date(year: nil, month: nil, date: nil)
+  def fills_in_stripe_expiry_date(year: nil, month: nil, date: nil)
     date ||= begin
       month = month.to_s.rjust(2, '0') unless month.is_a? String
       year = year.to_s[2..3] unless year.is_a? String
       "#{month}#{year}"
     end
 
-    fill_in_stripe_input 'expiry', with: date.to_s[0..3]
+    fills_in_stripe_input 'expiry', with: date.to_s[0..3]
   end
 
-  def fill_in_stripe_cvc(cvc)
-    fill_in_stripe_input 'cvc', with: cvc.to_s[0..2].to_s
+  def fills_in_stripe_cvc(cvc)
+    fills_in_stripe_input 'cvc', with: cvc.to_s[0..2].to_s
   end
 
-  def fill_in_stripe_country(country_name)
+  def fills_in_stripe_country(country_name)
     using_wait_time(10) do
-      within_frame(find_stripe_iframe) do
+      within_frame(finds_stripe_iframe) do
         find(%{select[name="country"]}).select(country_name)
       end
     end
   end
 
-  def fill_in_stripe_zip(zip)
-    fill_in_stripe_input 'postalCode', with: zip
+  def fills_in_stripe_zip(zip)
+    fills_in_stripe_input 'postalCode', with: zip
   end
 
-  def fill_in_stripe_input(name, with:)
+  def fills_in_stripe_input(name, with:)
     using_wait_time(10) do
-      within_frame(find_stripe_iframe) do
+      within_frame(finds_stripe_iframe) do
         with.to_s.chars.each { find(%{input[name="#{name}"]}).send_keys(_1) }
       end
     end
   end
 
-  # Assumes the presence of a #stripe_payment_method helper
-  def find_stripe_iframe
-    fieldset = find_payment_fieldset(stripe_payment_method.id)
+  def clears_stripe_form
+    %w[number expiry cvc postalCode].each do |name|
+      using_wait_time(10) do
+        within_frame(finds_stripe_iframe) do
+          field = find(%{input[name="#{name}"]})
+          field.value.length.times { field.send_keys [:backspace] }
+        end
+      end
+    end
+  end
+
+  def finds_stripe_iframe
+    fieldset = find_payment_fieldset(payment_method.id)
     expect(fieldset).to have_css('iframe') # trigger waiting if the frame is not yet there
     fieldset.find("iframe")
+  end
+
+  # 3D Secure methods
+  #
+  # These are methods that are used specifically for handling 3D Secure (3DS) payment
+  # authorizations.
+  #
+  # However, it's important to note that this process may require an additional step,
+  # (currently not fully supported), which is indicated by the "next_action" property
+  # of the Stripe PaymentIntent or SetupIntent object.
+  #
+  # More information on this property can be found in the Stripe API documentation:
+  # PaymentIntent objects : https://stripe.com/docs/api/payment_intents/object#payment_intent_object-next_action
+  # SetupIntent objects   : https://stripe.com/docs/api/setup_intents/object#setup_intent_object-next_action
+
+  def authorizes_3d_secure_payment(authenticate: true)
+    finds_frame('body > div > iframe') do
+      finds_frame('#challengeFrame') do
+        finds_frame("iframe[name='acsFrame']") do
+          click_on authenticate ? 'Complete authentication' : 'Fail authentication'
+        end
+      end
+    end
+  end
+
+  def authorizes_3d_secure_2_payment(authenticate: true)
+    finds_frame('body > div > iframe') do
+      finds_frame('#challengeFrame') do
+        click_on authenticate ? 'Complete' : 'Fail'
+      end
+    end
+  end
+
+  def finds_frame(selector, &block)
+    using_wait_time(15) do
+      frame = find(selector)
+      within_frame(frame, &block)
+    end
+  end
+
+  # Checkout methods
+  #
+  # These are methods that are used specifically for interacting with
+  # the checkout process.
+
+  def visits_payment_step(user: nil)
+    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
+
+    if user
+      sign_in order.user
+    else
+      assigns_guest_token order.guest_token
+    end
+
+    visit '/checkout/payment'
+  end
+
+  def chooses_new_stripe_payment
+    choose(option: payment_method.id)
+  end
+
+  def submits_payment
+    click_button("Save and Continue")
+  end
+
+  def checks_terms_of_service
+    expect(page).to have_content("Agree to Terms of Service")
+    check "Agree to Terms of Service"
+  end
+
+  def confirms_order
+    click_button("Place Order")
+  end
+
+  def completes_order
+    checks_terms_of_service
+    if payment_method.skip_confirm_step?
+      submits_payment
+    else
+      confirms_order
+    end
+
+    expect(page).to have_content('Your order has been processed successfully')
+  end
+
+  # Test methods
+  #
+  # These are methods that are used specifically for testing the Stripe
+  # checkout process.
+
+  def setup_intent_is_created_successfully
+    order = Spree::Order.last
+    intent = SolidusStripe::SetupIntent.retrieve_stripe_intent(
+      payment_method: payment_method,
+      order: order
+    )
+    expect(intent.status).to eq('succeeded')
+  end
+
+  def payment_intent_is_created_with_required_capture
+    order = Spree::Order.last
+    intent = SolidusStripe::PaymentIntent.where(
+      payment_method: payment_method,
+      order: order
+    ).last.stripe_intent
+    expect(intent.status).to eq('requires_capture')
+  end
+
+  def payment_intent_is_created_with_required_action
+    order = Spree::Order.last
+    intent = SolidusStripe::PaymentIntent.where(
+      payment_method: payment_method,
+      order: order
+    ).last.stripe_intent
+    expect(intent.status).to eq('requires_action')
+  end
+
+  def invalid_data_are_notified
+    fills_in_stripe_country('United States')
+
+    [
+      [{ number: '4242424242424241' }, 'Your card number is invalid'],  # incorrect_number
+      [{ date: '1110' }, "Your card's expiration year is in the past"], # invalid_expiry_year
+      [{ cvc: 99 }, "Your card's security code is incomplete"]          # invalid_cvc
+    ].each do |args, text|
+      clears_stripe_form
+      fills_stripe_form(**args)
+      submits_payment
+      using_wait_time(10) do
+        within_frame(finds_stripe_iframe) do
+          expect(page).to have_content(text)
+        end
+      end
+    end
+  end
+
+  def incomplete_cards_are_notified
+    # In order to have a complete Stripe form,
+    # it's essential to have a Postal Code field that will only be displayed
+    # when the user selects United States as their country.
+    fills_in_stripe_country('United States')
+
+    clears_stripe_form
+    submits_payment
+    [
+      "Your card number is incomplete",
+      "Your card's expiration date is incomplete",
+      "Your card's security code is incomplete",
+      "Your postal code is incomplete"
+    ].each do |text|
+      within_frame(finds_stripe_iframe) do
+        expect(page).to have_content(text)
+      end
+    end
+  end
+
+  def declined_cards_are_notified
+    fills_in_stripe_country('United States')
+
+    [
+      ['4000000000000002', 'Your card has been declined'],                   # Generic decline
+      ['4000000000009995', 'Your card has insufficient funds'],              # Insufficient funds decline
+      ['4000000000009987', 'Your card has been declined'],                   # Lost card decline
+      ['4000000000009979', 'Your card has been declined'],                   # Stolen card decline
+      ['4000000000000069', 'Your card has expired'],                         # Expired card decline
+      ['4000000000000127', "Your card's security code is incorrect"],        # Incorrect CVC decline
+      ['4000000000000119', 'An error occurred while processing your card']   # Processing error decline
+    ].each do |number, text|
+      clears_stripe_form
+      fills_stripe_form(number: number)
+      submits_payment
+      using_wait_time(15) do
+        expect(page).to have_content(text)
+      end
+    end
+  end
+
+  def successfully_creates_a_setup_intent(user: nil)
+    visits_payment_step(user: user)
+    chooses_new_stripe_payment
+    fills_stripe_form
+    submits_payment
+    expect(page).to have_content('Payment succeeded!')
+    setup_intent_is_created_successfully
+  end
+
+  def successfully_creates_a_payment_intent(user: nil)
+    visits_payment_step(user: user)
+    chooses_new_stripe_payment
+    fills_stripe_form
+
+    unless payment_method.skip_confirm_step?
+      submits_payment
+      expect(page).to have_content('Payment successfully authorized!')
+    end
+
+    completes_order
+    payment_intent_is_created_with_required_capture
   end
 end

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -2,218 +2,217 @@
 
 require 'solidus_stripe_spec_helper'
 
-RSpec.describe "Checkout with Stripe", :js do
+RSpec.describe 'SolidusStripe Checkout', :js do
   include SolidusStripe::CheckoutTestHelper
 
-  it "completes as a registered user and reuses the payment using setup intents" do
-    create(:stripe_payment_method, preferred_stripe_intents_flow: 'setup')
-    visit_payment_step(user: create(:user))
-    choose_new_stripe_payment
-    fill_stripe_form
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['checkout'])
-    confirm_order
-
-    order = Spree::Order.last
-    user = order.user
-    payment = order.payments.first
-    reusable_source = payment.source
-
-    expect(Spree::Order.count).to eq(1)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'])
-    payment.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
-    expect(SolidusStripe::PaymentSource.count).to eq(1)
-    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_present
-
-    # Pay with the newly created wallet source
-    visit_payment_step(user: user)
-    find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['checkout'])
-    confirm_order
-
-    order = Spree::Order.last
-    payment = order.payments.valid.first
-    expect(Spree::Order.count).to eq(2)
-    expect(order.user).to eq(user)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'])
-    expect(order.payments.valid.count).to eq(1)
-    payment.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
-    expect(SolidusStripe::PaymentSource.count).to eq(1)
-    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_present
-    expect(payment.source).to eq(reusable_source)
-  end
-
-  it "completes as a guest using setup intents" do
-    create(:stripe_payment_method, preferred_stripe_intents_flow: 'setup')
-    visit_payment_step(user: nil)
-    choose_new_stripe_payment
-    fill_stripe_form
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['checkout'])
-    confirm_order
-
-    order = Spree::Order.last
-    expect(Spree::Order.count).to eq(1)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'], outstanding: order.total)
-    order.payments.first.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
-  end
-
-  [true, false].each do |skip_confirm|
-    it "completes as a registered user using payment intents #{skip_confirm || ' not'} skipping confirm" do
-      create(
-        :stripe_payment_method,
-        preferred_stripe_intents_flow: 'payment',
-        preferred_skip_confirmation_for_payment_intent: skip_confirm,
-      )
-      visit_payment_step(user: create(:user))
-      choose_new_stripe_payment
-      fill_stripe_form
-
-      if skip_confirm
-        check "Agree to Terms of Service"
-        click_button("Save and Continue")
-        expect(page).to have_content("Your order has been processed successfully")
-      else
-        submit_payment
-        expect_payments_state(Spree::Order.last, ['pending'])
-        confirm_order
+  # To learn more about setup_future_usage in different contexts with Stripe Setup Intents:
+  # https://stripe.com/docs/payments/setup-intents#increasing-success-rate-by-specifying-usage
+  ['on_session', 'off_session'].each do |setup_future_usage|
+    context "with Stripe Setup Intents and setup_future_usage=#{setup_future_usage}" do
+      before do
+        creates_payment_method(
+          intents_flow: 'setup',
+          setup_future_usage: setup_future_usage
+        )
       end
 
-      order = Spree::Order.last
-      payment = order.payments.first
+      context 'with a registered user' do
+        it 'creates a setup intent and successfully processes payment' do
+          successfully_creates_a_setup_intent(user: create(:user))
+          completes_order
+          payment_intent_is_created_with_required_capture
+          captures_last_valid_payment
+        end
 
-      expect(Spree::Order.count).to eq(1)
-      expect_checkout_completion(order)
-      expect_payments_state(order, ['pending'])
-      payment.capture!
-      expect_payments_state(order, ['completed'], outstanding: 0)
-      expect(SolidusStripe::PaymentSource.count).to eq(1)
-      expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_blank
+        it "successfully reuses a previously saved card from the user's wallet" do
+          user = create(:user)
+
+          successfully_creates_a_setup_intent(user: user)
+          completes_order
+          payment_intent_is_created_with_required_capture
+          captures_last_valid_payment
+
+          visits_payment_step(user: user)
+          find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
+          submits_payment
+          completes_order
+          payment_intent_is_created_with_required_capture
+          captures_last_valid_payment
+        end
+
+        it 'creates a setup intent with a 3D Secure card and successfully processes payment' do
+          visits_payment_step(user: create(:user))
+          chooses_new_stripe_payment
+
+          # Fill in the Stripe payment form with a 3D Secure card
+          # This card requires authentication on all transactions,
+          # regardless of how the card is set up.
+          # See https://stripe.com/docs/testing#authentication-and-setup for more information on this card.
+          fills_stripe_form(number: '4000002760003184')
+
+          # Submit the payment form and authorize the 3D Secure payment
+          submits_payment
+          authorizes_3d_secure_payment
+
+          # Expect the setup intent to be created successfully and complete the order
+          setup_intent_is_created_successfully
+          completes_order
+
+          # Note that, in case of a Setup Intent, even if it is authorized, the payment intent
+          # cannot be captured because a required action is needed most of the times.
+          payment_intent_is_created_with_required_action
+
+          # A solution needs to be implemented to handle the required action for these cards.
+          pending 'These cards cannot be reused as the required action is not handled'
+
+          payment_intent_is_created_with_required_capture
+          captures_last_valid_payment
+        end
+      end
+
+      context 'with a guest user' do
+        it 'creates a setup intent and successfully processes payment' do
+          successfully_creates_a_setup_intent
+          completes_order
+          payment_intent_is_created_with_required_capture
+          captures_last_valid_payment
+        end
+      end
     end
   end
 
-  it "completes as a guest using payment intents" do
-    create(
-      :stripe_payment_method,
-      preferred_stripe_intents_flow: 'payment',
-      preferred_skip_confirmation_for_payment_intent: false,
-    )
-    visit_payment_step(user: nil)
-    choose_new_stripe_payment
-    fill_stripe_form
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['pending'])
-    confirm_order
+  # To learn more about setup_future_usage in different contexts with Stripe Payment Intents:
+  # https://stripe.com/docs/payments/payment-intents#future-usage
+  ['', 'on_session', 'off_session'].each do |setup_future_usage|
+    context "with Stripe Payment Intents and setup_future_usage=#{setup_future_usage}" do
+      let(:skip_confirm_step) { true }
 
-    order = Spree::Order.last
-    expect(Spree::Order.count).to eq(1)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'], outstanding: order.total)
-    order.payments.first.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
+      before do
+        creates_payment_method(
+          intents_flow: 'payment',
+          setup_future_usage: setup_future_usage,
+          skip_confirmation: skip_confirm_step
+        )
+      end
+
+      context 'with a registered user and skip_confirmation_for_payment_intent = true' do
+        it 'creates a payment intent and successfully processes payment' do
+          successfully_creates_a_payment_intent(user: create(:user))
+
+          captures_last_valid_payment
+        end
+
+        it 'creates a payment intent and successfully processes payment with 3d secure card' do
+          visits_payment_step(user: create(:user))
+          chooses_new_stripe_payment
+
+          # Fill in the Stripe payment form with a 3D Secure card
+          # This card requires authentication on all transactions, regardless
+          # of how the card is set up.
+          # See https://stripe.com/docs/testing#authentication-and-setup for more information on this card.
+          fills_stripe_form(number: '4000002760003184')
+
+          # Submit the payment form and authorize the 3D Secure payment
+          checks_terms_of_service
+          submits_payment
+          authorizes_3d_secure_payment
+          expect(page).to have_content('Your order has been processed successfully')
+          payment_intent_is_created_with_required_capture
+
+          captures_last_valid_payment
+        end
+
+        # Payment sources that are not specified for future usage cannot be
+        # reused and are not added to the user's wallet
+        if setup_future_usage.present?
+          it "successfully reuses a previously saved card from the user's wallet" do
+            user = create(:user)
+
+            successfully_creates_a_payment_intent(user: user)
+            captures_last_valid_payment
+
+            visits_payment_step(user: user)
+            find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
+            submits_payment
+            checks_terms_of_service
+            confirms_order
+            expect(page).to have_content('Your order has been processed successfully')
+            payment_intent_is_created_with_required_capture
+            captures_last_valid_payment
+          end
+        end
+      end
+
+      context 'with a registered user and skip_confirmation_for_payment_intent = false' do
+        let(:skip_confirm_step) { false }
+
+        it 'creates a payment intent and successfully processes payment' do
+          successfully_creates_a_payment_intent(user: create(:user))
+
+          captures_last_valid_payment
+        end
+      end
+
+      context 'with a guest user' do
+        it 'creates a payment intent and successfully processes payment' do
+          successfully_creates_a_payment_intent
+
+          captures_last_valid_payment
+        end
+      end
+    end
   end
 
-  it "completes as a registered user and reuses the payment using payment intents" do
-    create(
-      :stripe_payment_method,
-      preferred_stripe_intents_flow: 'payment',
-      preferred_setup_future_usage: 'off_session',
-      preferred_skip_confirmation_for_payment_intent: false,
-    )
+  context 'with declined cards' do
+    it 'reject transactions with declined cards or invalid fields and return an appropriate response' do
+      creates_payment_method
+      visits_payment_step(user: create(:user))
+      chooses_new_stripe_payment
 
-    # Pay for the first time
-    visit_payment_step(user: create(:user))
-    choose_new_stripe_payment
-    fill_stripe_form
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['pending'])
-    confirm_order
+      # Refer to https://stripe.com/docs/testing#invalid-data for more
+      # information on generating test data with invalid values.
+      invalid_data_are_notified
 
-    order = Spree::Order.last
-    user = order.user
-    payment = order.payments.first
-    reusable_source = payment.source
+      # Generic error field messages that appear when the Stripe form
+      # has incomplete data for cards
+      incomplete_cards_are_notified
 
-    expect(Spree::Order.count).to eq(1)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'])
-    payment.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
-    expect(SolidusStripe::PaymentSource.count).to eq(1)
-    expect(reusable_source.stripe_payment_method_id).to be_present
-
-    # Pay with the newly created wallet source
-    visit_payment_step(user: user)
-    find_existing_payment_radio(user.wallet_payment_sources.first.id).choose
-    submit_payment
-    expect_payments_state(Spree::Order.last, ['checkout'])
-    confirm_order
-
-    order = Spree::Order.last
-    payment = order.payments.valid.first
-    expect(Spree::Order.count).to eq(2)
-    expect(order.user).to eq(user)
-    expect_checkout_completion(order)
-    expect_payments_state(order, ['pending'])
-    expect(order.payments.valid.count).to eq(1)
-    payment.capture!
-    expect_payments_state(order, ['completed'], outstanding: 0)
-    expect(SolidusStripe::PaymentSource.count).to eq(1)
-    expect(SolidusStripe::PaymentSource.last.stripe_payment_method_id).to be_present
-    expect(payment.source).to eq(reusable_source)
-  end
-
-  private
-
-  def stripe_payment_method
-    # Memoize the payment method id to avoid fetching it multiple times
-    @stripe_payment_method ||= SolidusStripe::PaymentMethod.first!
-  end
-
-  def visit_payment_step(user: nil)
-    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
-
-    if user
-      sign_in order.user
-    else
-      assign_guest_token order.guest_token
+      # Check the Stripe documentation for more information on
+      # how to test declined payments:
+      # https://stripe.com/docs/testing#declined-payments
+      declined_cards_are_notified
     end
 
-    visit '/checkout/payment'
-  end
+    context 'with 3D Secure cards' do
+      it 'reject transaction with failed authentication and return an appropriate response' do
+        creates_payment_method
+        visits_payment_step(user: create(:user))
+        chooses_new_stripe_payment
+        fills_in_stripe_country('United States')
 
-  def choose_new_stripe_payment
-    choose(option: stripe_payment_method.id)
-  end
+        # This 3D Secure card requires authentication for all transactions,
+        # regardless of its setup.
+        # Please refer to the Stripe documentation for more information:
+        # https://stripe.com/docs/testing#authentication-and-setup
+        fills_stripe_form(number: '4000002760003184')
+        submits_payment
+        authorizes_3d_secure_payment(authenticate: false)
+        using_wait_time(15) do
+          expect(page).to have_content('An unexpected error occurred')
+        end
 
-  def submit_payment
-    click_button("Save and Continue")
-    expect(page).to have_content("Agree to Terms of Service")
-  end
-
-  def confirm_order
-    check "Agree to Terms of Service"
-    click_button("Place Order")
-    expect(page).to have_content("Your order has been processed successfully")
-  end
-
-  def expect_checkout_completion(order = Spree::Order.last)
-    expect(page).to have_content("Your order has been processed successfully")
-    expect(page).to have_content(order.number)
-    expect(order).to be_complete
-    expect(order).to be_completed
-  end
-
-  def expect_payments_state(order, states, outstanding: order.total)
-    expect(order.payments.valid.sum(:amount)).to eq(order.total)
-    expect(order.payments.reload.pluck(:state)).to eq(states)
-    expect(order.outstanding_balance.to_f).to eq(outstanding)
+        # This test script is using 3D Secure 2 authentication, which must be
+        # completed for the payment to be successful.
+        # Please refer to the Stripe documentation for more information:
+        # https://stripe.com/docs/testing#three-ds-cards
+        clears_stripe_form
+        fills_stripe_form(number: '4000000000003220')
+        submits_payment
+        authorizes_3d_secure_2_payment(authenticate: false)
+        using_wait_time(15) do
+          expect(page).to have_content('An unexpected error occurred')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Closes #166

This pull request adds improved test coverage for using the gem with [solidus_starter_frontend](https://github.com/solidusio/solidus_starter_frontend).
The `checkout_spec.rb` has been refactored to include specific use cases with the addition of new scenarios and reorganized test blocks.

The tests cover the following cases:

| Intents flow| Description| Setup Feature Usage | Skip Confirm Step | User | Guest | Payment Result|
|-:|:-|:-:|:-:|:-:|:-:|:-|
| Setup Intent | Credit card with payment capture and wallet reuse | all | no| yes| yes | Successfully created/processed/reused |
| Setup Intent | 3D secure card without capture | all | no| yes | | Required action present |
| Payment Intent | Credit card with payment capture and wallet reuse | all | yes/no | yes| yes | Successfully created/processed/reused |
| Payment Intent | 3D secure card with payment capture | all| yes | yes | | Successfully created/processed |
| Setup Intent | 3D secure card authentication failure | - | -| yes | | Failed authentication |
| Setup Intent | Transaction failure for incorrect data | - | -| yes | | Failed transaction |
| Setup Intent| Incomplete data form submission failure | - | -| yes | | Failed submission |

These tests help ensure the reliability and stability of the gem when used with [solidus_starter_frontend](https://github.com/solidusio/solidus_starter_frontend).

Closes also #187

This PR includes tests that cover all the cards mentioned in the issue ([card that will be declined](https://stripe.com/docs/testing#declined-payments)). 
The issues mentioned in the ticket may be related to previous situations addressed in other PRs:
<details>
    <summary>Refer to the video below to see the current situation in a test environment</summary>
   
  <video src="https://user-images.githubusercontent.com/19948291/224904672-36324941-0a5f-4b2d-9a5a-3049b376cbb7.mov"/>
</details>


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.

## Reviewer Guidelines
To better review the changes made to `checkout_spec.rb`, I suggest reviewing them on the branch rather than the diff.

Here is a link to the relevant file:
[solidus_stripe/spec/system/frontend/solidus_stripe/checkout_spec.rb](https://github.com/solidusio/solidus_stripe/blob/nebulab/rainerd/add-test-coverag-for-the-integration-with-solidus-starter-frontend/spec/system/frontend/solidus_stripe/checkout_spec.rb)
(I can split it into multiple commits if needed)