### PR TITLE
Add SolidusStripe::Customer

### DIFF
--- a/app/models/solidus_stripe/customer.rb
+++ b/app/models/solidus_stripe/customer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  class Customer < ApplicationRecord
+    belongs_to :payment_method
+
+    # Source is supposed to be a user or an order and needs to respond to #email
+    belongs_to :source, polymorphic: true
+
+    def self.retrieve_or_create_stripe_customer_id(payment_method:, order:)
+      instance = find_or_initialize_by(payment_method: payment_method, source: order.user || order)
+
+      instance.stripe_id ||
+        instance.create_stripe_customer.tap { instance.update!(stripe_id: _1.id) }.id
+    end
+
+    def create_stripe_customer
+      payment_method.gateway.request { Stripe::Customer.create(email: source.email) }
+    end
+  end
+end

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -21,7 +21,10 @@ module SolidusStripe
     end
 
     def create_stripe_intent(stripe_intent_options)
-      customer = payment_method.customer_for(order)
+      stripe_customer_id = SolidusStripe::Customer.retrieve_or_create_stripe_customer_id(
+        payment_method: payment_method,
+        order: order
+      )
 
       payment_method.gateway.request do
         Stripe::PaymentIntent.create({
@@ -35,7 +38,7 @@ module SolidusStripe
           # avoid capturing the money before the order is completed.
           capture_method: 'manual',
           setup_future_usage: payment_method.preferred_setup_future_usage.presence,
-          customer: customer,
+          customer: stripe_customer_id,
           metadata: { solidus_order_number: order.number },
         }.merge(stripe_intent_options))
       end

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -52,52 +52,6 @@ module SolidusStripe
       end
     end
 
-    concerning :Customer do
-      def customer_for(order)
-        if order.user
-          find_customer_for_user(order.user) || create_customer_for_user(order.user)
-        else
-          find_customer_for_order(order) || create_customer_for_order(order)
-        end
-      end
-
-      def find_customer_for_user(user)
-        gateway.request do
-          raise "unsupported email address: #{user.email.inspect}" if user.email.include?("'")
-
-          Stripe::Customer.search(
-            query: "metadata['solidus_user_id']:'#{user.id}' AND email:'#{user.email}'"
-          ).first
-        end
-      end
-
-      def create_customer_for_user(user)
-        gateway.request do
-          Stripe::Customer.create(
-            email: user.email,
-            metadata: { solidus_user_id: user.id },
-          )
-        end
-      end
-
-      def find_customer_for_order(order)
-        gateway.request do
-          Stripe::Customer.search(
-            query: "metadata['solidus_order_number']:'#{order.number}'"
-          ).first
-        end
-      end
-
-      def create_customer_for_order(order)
-        gateway.request do
-          Stripe::Customer.create(
-            email: order.email,
-            metadata: { solidus_order_number: order.number },
-          )
-        end
-      end
-    end
-
     def skip_confirm_step?
       preferred_stripe_intents_flow == 'payment' &&
         preferred_skip_confirmation_for_payment_intent

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -21,11 +21,14 @@ module SolidusStripe
     end
 
     def create_stripe_intent(stripe_intent_options)
-      customer = payment_method.customer_for(order)
+      stripe_customer_id = SolidusStripe::Customer.retrieve_or_create_stripe_customer_id(
+        payment_method: payment_method,
+        order: order
+      )
 
       payment_method.gateway.request do
         Stripe::SetupIntent.create({
-          customer: customer,
+          customer: stripe_customer_id,
           usage: payment_method.preferred_setup_future_usage.presence,
           metadata: { solidus_order_number: order.number },
         }.merge(stripe_intent_options))

--- a/db/migrate/20230313150008_create_solidus_stripe_customers.rb
+++ b/db/migrate/20230313150008_create_solidus_stripe_customers.rb
@@ -1,0 +1,16 @@
+class CreateSolidusStripeCustomers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solidus_stripe_customers do |t|
+      t.references :payment_method, null: false, foreign_key: { to_table: :spree_payment_methods }
+
+      t.string :source_type
+      t.integer :source_id
+
+      t.string :stripe_id, index: true
+
+      t.timestamps
+
+      t.index [:payment_method_id, :source_type, :source_id], unique: true, name: :payment_method_and_source
+    end
+  end
+end

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -38,4 +38,14 @@ FactoryBot.define do
     association :payment_method, factory: :stripe_payment_method
     slug { SecureRandom.hex(16) }
   end
+
+  factory :stripe_customer, class: 'SolidusStripe::Customer' do
+    association :payment_method, factory: :stripe_payment_method
+    association :source, factory: :user
+    stripe_id { "cus_#{SecureRandom.uuid.delete('-')}" }
+
+    trait :guest do
+      association :source, factory: :order, email: 'guest@example.com', user: nil
+    end
+  end
 end

--- a/spec/models/solidus_stripe/customer_spec.rb
+++ b/spec/models/solidus_stripe/customer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'solidus_stripe_spec_helper'
+
+RSpec.describe SolidusStripe::Customer, type: :model do
+  describe ".retrieve_or_create_stripe_customer_id" do
+    context 'with an existing customer' do
+      it 'returns the customer_id' do
+        user = create(:user)
+        order = create(:order, user: user)
+        customer = create(:stripe_customer, stripe_id: 'cus_123', source: user)
+
+        expect(customer.source).to be_a(Spree::User)
+        expect(
+          described_class.retrieve_or_create_stripe_customer_id(order: order, payment_method: customer.payment_method)
+        ).to eq('cus_123')
+      end
+    end
+
+    context 'without an existing customer' do
+      it 'creates the customer from a user' do
+        user = create(:user, email: 'registered@example.com')
+        order = create(:order, user: user)
+        payment_method = create(:stripe_payment_method)
+
+        stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
+        allow(Stripe::Customer).to receive(:create).with(email: 'registered@example.com').and_return(stripe_customer)
+
+        expect(
+          described_class.retrieve_or_create_stripe_customer_id(order: order, payment_method: payment_method)
+        ).to eq('cus_123')
+      end
+
+      it 'creates the customer from a guest order' do
+        payment_method = create(:stripe_payment_method)
+        order = create(:order, user: nil, email: 'guest@example.com')
+
+        stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
+        allow(Stripe::Customer).to receive(:create).with(email: 'guest@example.com').and_return(stripe_customer)
+
+        expect(
+          described_class.retrieve_or_create_stripe_customer_id(order: order, payment_method: payment_method)
+        ).to eq('cus_123')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #163

Adds a `SolidusStripe::Customer` class that connects the user or the order (for guest users) to a stripe customer, ensuring it stays the same across order and intents generation.

- Use a polymorphic association to allow connecting it to either users or orders (for guest users)
- Stop using metadata since we now store the id and we can rely on the database for fetching it
- No need for fetching the customer form the API anywhere in the current implementation

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
