### PR TITLE
Always create Solidus counter-part when creating Stripe payment intent

### DIFF
--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -85,17 +85,15 @@ module SolidusStripe
     end
 
     # Authorizes and captures a certain amount on the provided payment source.
-    def purchase(amount_in_cents, _source, options = {})
-      currency = options.fetch(:currency)
-
+    # @todo add support for purchasing custom amounts
+    def purchase(_amount_in_cents, source, options = {})
       # Charge the Customer instead of the card:
-      payment_intent = request do
-        Stripe::PaymentIntent.create({
-          amount: to_stripe_amount(amount_in_cents, currency),
-          currency: currency,
-          **options[:payment_intent_options].to_h
-        })
-      end
+      payment_intent =
+        SolidusStripe::PaymentIntent.create_stripe_intent(
+          payment_method: source.payment_method,
+          order: options[:originator].order,
+          stripe_intent_options: options[:payment_intent_options] || {}
+        )
 
       build_payment_log(
         success: true,

--- a/app/models/solidus_stripe/setup_intent.rb
+++ b/app/models/solidus_stripe/setup_intent.rb
@@ -5,14 +5,13 @@ module SolidusStripe
     belongs_to :order, class_name: 'Spree::Order'
     belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    def self.retrieve_or_create_stripe_intent(payment_method:, order:)
-      instance = find_or_initialize_by(payment_method: payment_method, order: order)
+    def self.retrieve_stripe_intent(payment_method:, order:)
+      find_by(payment_method: payment_method, order: order)&.stripe_intent
+    end
 
-      if instance.stripe_intent_id
-        instance.stripe_intent
-      else
-        instance.create_stripe_intent.tap { instance.update!(stripe_intent_id: _1.id) }
-      end
+    def self.create_stripe_intent(payment_method:, order:, stripe_intent_options: {})
+      instance = new(payment_method: payment_method, order: order)
+      instance.create_stripe_intent(stripe_intent_options).tap { instance.update!(stripe_intent_id: _1.id) }
     end
 
     def stripe_intent
@@ -21,7 +20,7 @@ module SolidusStripe
       end
     end
 
-    def create_stripe_intent
+    def create_stripe_intent(stripe_intent_options)
       customer = payment_method.customer_for(order)
 
       payment_method.gateway.request do
@@ -29,7 +28,7 @@ module SolidusStripe
           customer: customer,
           usage: 'off_session', # TODO: use the payment method's preference
           metadata: { solidus_order_number: order.number },
-        })
+        }.merge(stripe_intent_options))
       end
     end
   end

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -10,10 +10,10 @@
 <% end %>
 
 <%# TODO: See if we can move the intent creation out of the view %>
-<% intent = intent_class.retrieve_or_create_stripe_intent(
-  payment_method: payment_method,
-  order: current_order,
-) %>
+<% intent =
+     intent_class.retrieve_stripe_intent(payment_method: payment_method, order: current_order) ||
+     intent_class.create_stripe_intent(payment_method: payment_method, order: current_order)
+%>
 
 <div
   class="solidus-stripe-payment"


### PR DESCRIPTION
## Summary

That'll allow us always to fetch the associated order when receiving an incoming payment intent webhook.

Until now, we were only creating the Solidus counterpart when going through the payment intent flow and not reusing a source. As the payment made that way is already authorized, the `purchase` method is not reached, so we don't end up with two payment intent resources.

The refactor makes our limitation more evident, where we can capture only the whole order amount.

We're also splitting the find & create paths for the intent models methods. The idea is to call `.create_stripe_intent` and not `retrieve_or_create_stripe_intent` when we already know that the intent is not there (i.e., from the gateway).

Closes #218 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
