### PR TITLE
Coverage: deprecated gem, install_generator tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.1
+  codecov: codecov/codecov@3.2.4
 
   # Always take the latest version of the orb, this allows us to
   # run specs against Solidus supported versions only without the need
@@ -69,11 +70,16 @@ jobs:
           command: |
             <<#parameters.coverage>>export COVERAGE=true<</parameters.coverage>>
             bin/rspec --format progress --format RspecJunitFormatter --out "$PWD/test-results/results.xml"
-      - store_test_results:
+      - when:
+          condition: <<parameters.coverage>>
+          steps: ["codecov/upload"]
           path: test-results
       - store_artifacts:
           path: /home/circleci/project/dummy-app/tmp/capybara/
           destination: capybara
+      - store_artifacts:
+          path: /home/circleci/project/coverage/
+          destination: coverage
   lint-code:
     executor: solidusio_extensions/sqlite-memory
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,9 @@ jobs:
             bundle install
       - run:
           name: "Install dummy app"
-          command: bin/dummy-app
+          command: |
+            <<#parameters.coverage>>export COVERAGE=true<</parameters.coverage>>
+            bin/dummy-app
           environment:
             FRONTEND: starter
             SOLIDUS_BRANCH: master

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ gem 'listen'
 
 gem 'activestorage'
 
-gem 'codecov', require: false
 gem 'rspec_junit_formatter', require: false
 gem 'simplecov', '~> 0.22', require: false
+gem 'simplecov-cobertura', require: false

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -29,9 +29,9 @@ cd ./dummy-app
 
 # Coverage
 echo "require_relative '../../coverage.rb' if ENV['COVERAGE']" >> config/boot.rb
-echo "gem 'simplecov', '~> 0.22', require: false" >> Gemfile
 echo "gem 'rspec_junit_formatter', require: false" >> Gemfile
-echo "gem 'codecov', require: false" >> Gemfile
+echo "gem 'simplecov', '~> 0.22', require: false" >> Gemfile
+echo "gem 'simplecov-cobertura', require: false" >> Gemfile
 unbundled bundle install
 
 unbundled bundle add solidus --github solidusio/solidus --branch "${SOLIDUS_BRANCH:-master}" --version '> 0.a'

--- a/coverage.rb
+++ b/coverage.rb
@@ -6,20 +6,10 @@ require 'simplecov'
 SimpleCov.root File.expand_path(__dir__)
 
 if ENV['CODECOV_TOKEN']
-  require 'codecov'
-
-  class FixedCodeCovFormatter
-    # The `file_network` method will run a wildcard from inside the current dir
-    # instead of inside the SimpleCov root.
-    def format(result)
-      Dir.chdir(SimpleCov.root) do
-        SimpleCov::Formatter::Codecov.new.format(result)
-      end
-    end
-  end
+  require 'simplecov-cobertura'
 
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-    FixedCodeCovFormatter,
+    SimpleCov::Formatter::CoberturaFormatter,
     SimpleCov.formatter,
   ])
 else

--- a/coverage.rb
+++ b/coverage.rb
@@ -33,6 +33,7 @@ def (SimpleCov::ResultAdapter).call(result)
   result
 end
 
+warn "Tracking coverage on process #{$$}..."
 SimpleCov.start do
   root __dir__
   enable_coverage_for_eval


### PR DESCRIPTION
## Summary

- I randomly landed on the `codecov` gem repository and found that they urge everyone to migrate to a different setup
- Start tracking coverage for the install generator

Follow up to #204
Reference #211

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
