### PR TITLE
Fix `Gateway#purchase` not capturing the payment

### DIFF
--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -48,4 +48,18 @@ FactoryBot.define do
       association :source, factory: :order, email: 'guest@example.com', user: nil
     end
   end
+
+  factory :order_with_stripe_payment, parent: :order do
+    transient do
+      amount { 10 }
+      payment_method { build(:stripe_payment_method) }
+    end
+
+    line_items { [build(:line_item, price: amount)] }
+
+    after(:create) do |order, evaluator|
+      build(:payment, amount: evaluator.amount, order: order, payment_method: evaluator.payment_method)
+      order.recalculate
+    end
+  end
 end

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -132,13 +132,13 @@ RSpec.describe SolidusStripe::Gateway do
   describe '#void' do
     it 'voids a payment that hasn not been captured yet' do
       gateway = build(:stripe_payment_method).gateway
-      intent = Stripe::PaymentIntent.construct_from(id: "pi_123", object: "payment_intent")
-      allow(Stripe::PaymentIntent).to receive(:cancel).and_return(intent)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      allow(Stripe::PaymentIntent).to receive(:cancel).and_return(stripe_payment_intent)
 
       result = gateway.void('pi_123', :source)
 
       expect(Stripe::PaymentIntent).to have_received(:cancel).with('pi_123')
-      expect(result.params).to eq("data" => '{"id":"pi_123","object":"payment_intent"}')
+      expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 
     it "raises if no payment_intent_id is given" do


### PR DESCRIPTION
## Summary

On Solidus, `Gateway#purchase` is meant to authorize and capture a payment in a single step. However, we were using that method only to authorize (confirm, on Stripe) the payment.

We're now moving the authorize logic to a helper method shared by the `#authorize` and `#purchase` methods, while we use the `automatic` capture method on `#purchase`.

We're also unifying the format for the success messages recorded in the response.

We're getting rid of the option to pass custom payment intent options on `#authorize`. That was the only method in the gateway supporting them, and we can add it later to all the methods if we feel that's needed.

Closes #232

We take the occasion to perform some house-keeping (two last commits):

- Extract and reuse checks on the Gateway method arguments. We were only performing safety checks against `Gateway#capture` arguments. However, they also make sense for the other methods in the class. We're also adding unit tests for those checks.
- Unify naming convention for variables in the gateway tests

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
