### PR TITLE
Adapt to latest SSF changes

### DIFF
--- a/spec/solidus_stripe_spec_helper.rb
+++ b/spec/solidus_stripe_spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'stripe'
-require 'solidus_starter_frontend_helper'
+require 'solidus_starter_frontend_spec_helper'
 
 Dir["#{__dir__}/support/solidus_stripe/**/*.rb"].sort.each { |f| require f }
 

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'solidus_starter_frontend_helper'
+require 'solidus_starter_frontend_spec_helper'
 
 module SolidusStripe::CheckoutTestHelper
-  include SystemHelpers
+  include SolidusStarterFrontend::SystemHelpers
   def self.included(base)
     base.include Devise::Test::IntegrationHelpers
   end


### PR DESCRIPTION
## Summary

After latest changes on SSF (see https://github.com/solidusio/solidus_starter_frontend/pull/327), we need to:

- Scope the `SystemHelper` module within `SolidusStarterFrontend`.
- Rename the RSpec helper to `solidus_starter_frontend_spec_helper`

Closes #234 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
