### PR TITLE
Guarantee payment is linked to payment intent when receiving webhooks

### DIFF
--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       allow(source).to receive(:stripe_payment_method).and_return(stripe_payment_method)
       allow(Stripe::PaymentIntent).to receive(:create).and_return(stripe_payment_intent)
+      allow(Stripe::PaymentIntent).to receive(:confirm).with("pi_123").and_return(stripe_payment_intent)
 
       result = gateway.authorize(123_45, source, currency: 'USD', originator: order.payments.first)
 
@@ -22,12 +23,13 @@ RSpec.describe SolidusStripe::Gateway do
         amount: 123_45,
         currency: 'USD',
         capture_method: 'manual',
-        confirm: true,
+        confirm: false,
         metadata: { solidus_order_number: order.number },
         customer: "cus_123",
         payment_method: "pm_123",
         setup_future_usage: nil
       )
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 
@@ -102,6 +104,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       allow(source).to receive(:stripe_payment_method).and_return(stripe_payment_method)
       allow(Stripe::PaymentIntent).to receive(:create).and_return(stripe_payment_intent)
+      allow(Stripe::PaymentIntent).to receive(:confirm).with("pi_123").and_return(stripe_payment_intent)
 
       result = gateway.purchase(123_45, source, currency: 'USD', originator: order.payments.first)
 
@@ -109,12 +112,13 @@ RSpec.describe SolidusStripe::Gateway do
         amount: 123_45,
         currency: 'USD',
         capture_method: 'automatic',
-        confirm: true,
+        confirm: false,
         metadata: { solidus_order_number: order.number },
         customer: "cus_123",
         payment_method: "pm_123",
         setup_future_usage: nil
       )
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 


### PR DESCRIPTION
## Summary

We create and confirm the Stripe payment intent in two steps. That's to
guarantee that we associate a Solidus payment on the creation, and we
can fetch it after webhook events are published on confirmation.

Closes #231

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
