### PR TITLE
Copy id over Solidus' payment response_code on Stripe's payment intent creation

### DIFF
--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe SolidusStripe::Gateway do
       source = build(:stripe_payment_source, stripe_payment_method_id: "pi_123", payment_method: payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      payment = order.payments.last
 
       allow(source).to receive(:stripe_payment_method).and_return(stripe_payment_method)
       allow(Stripe::PaymentIntent).to receive(:create).and_return(stripe_payment_intent)
@@ -31,6 +32,7 @@ RSpec.describe SolidusStripe::Gateway do
       )
       expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
+      expect(payment.reload.response_code).to eq("pi_123")
     end
 
     it "raises if the given amount doesn't match the order total" do
@@ -101,6 +103,7 @@ RSpec.describe SolidusStripe::Gateway do
       source = build(:stripe_payment_source, stripe_payment_method_id: "pi_123", payment_method: payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      payment = order.payments.last
 
       allow(source).to receive(:stripe_payment_method).and_return(stripe_payment_method)
       allow(Stripe::PaymentIntent).to receive(:create).and_return(stripe_payment_intent)
@@ -120,6 +123,7 @@ RSpec.describe SolidusStripe::Gateway do
       )
       expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
+      expect(payment.reload.response_code).to eq("pi_123")
     end
 
     it "raises if the given amount doesn't match the order total" do


### PR DESCRIPTION
## Summary

On #222, we're handling the `payment_intent.succeeded` webhook by fetching the associated payment via the `Spree::Payment#response_code` field. However, the response code wasn't filled until after the authorization was completed on Stripe. Once we implement auto-capture (see #178), that could be an issue, as we could receive the webhook before the column update.

We're now filling `response_code` just after the payment intent creation, which always happens before confirmation on Stripe (see #231).

Closes #238

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
