### PR TITLE
Fix error when completing an order with a card declined at confirmation

### DIFF
--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -48,7 +48,13 @@ module SolidusStripe
         success: true,
         message: "PaymentIntent was confirmed successfully",
         response_code: stripe_payment_intent.id,
-        data: stripe_payment_intent,
+        data: stripe_payment_intent
+      )
+    rescue Stripe::StripeError => e
+      build_payment_log(
+        success: false,
+        message: e.message,
+        data: e.response
       )
     end
 

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe SolidusStripe::Gateway do
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 
+    it 'generates error response on failure' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123", customer: "cus_123")
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+
+      payment_method = build(:stripe_payment_method)
+      source = build(:stripe_payment_source, stripe_payment_method_id: "pi_123", payment_method: payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+
+      allow(source).to receive(:stripe_payment_method).and_return(stripe_payment_method)
+      allow(Stripe::PaymentIntent).to receive(:create).and_return(stripe_payment_intent)
+      allow(Stripe::PaymentIntent).to receive(:confirm).with("pi_123").and_raise(Stripe::StripeError.new("auth error"))
+
+      result = gateway.authorize(123_45, source, currency: 'USD', originator: order.payments.first)
+
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
+      expect(result.success?).to be(false)
+      expect(result.message).to eq("auth error")
+    end
+
     it "raises if the given amount doesn't match the order total" do
       payment_method = build(:stripe_payment_method)
       gateway = payment_method.gateway

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'SolidusStripe Checkout', :js do
   end
 
   context 'with declined cards' do
-    it 'reject transactions with declined cards or invalid fields and return an appropriate response' do
+    it 'reject transactions with cards declined at intent creation or invalid fields and return an appropriate response' do # rubocop:disable Metrics/LineLength
       creates_payment_method
       visits_payment_step(user: create(:user))
       chooses_new_stripe_payment
@@ -180,7 +180,17 @@ RSpec.describe 'SolidusStripe Checkout', :js do
       # Check the Stripe documentation for more information on
       # how to test declined payments:
       # https://stripe.com/docs/testing#declined-payments
-      declined_cards_are_notified
+      declined_cards_at_intent_creation_are_notified
+    end
+
+    it 'reject transactions with cards declined at the confirm step and return an appropriate response' do
+      creates_payment_method(
+        intents_flow: 'setup'
+      )
+      visits_payment_step(user: create(:user))
+      chooses_new_stripe_payment
+
+      declined_cards_at_confirm_are_notified
     end
 
     context 'with 3D Secure cards' do


### PR DESCRIPTION
## Summary

Stripe denies some payments at the confirmation stage, rather than in submitting the form. For those situations, we need to revert the order to the payment step and fail the payment.

Fixes #224

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
