### PR TITLE
Handle payment_intent.failed event

### DIFF
--- a/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
@@ -7,6 +7,7 @@ module SolidusStripe
       include Omnes::Subscriber
 
       handle :"stripe.payment_intent.succeeded", with: :complete_payment
+      handle :"stripe.payment_intent.payment_failed", with: :fail_payment
 
       # Captures a payment.
       #
@@ -15,8 +16,7 @@ module SolidusStripe
       #
       # @param event [SolidusStripe::Webhook::Event]
       def complete_payment(event)
-        payment_intent_id = event.data.object.id
-        payment = Spree::Payment.find_by!(response_code: payment_intent_id)
+        payment = extract_payment_from_event(event)
         return if payment.completed?
 
         payment.complete!.tap do
@@ -26,6 +26,32 @@ module SolidusStripe
             message: "Capture was successful after payment_intent.succeeded webhook"
           )
         end
+      end
+
+      # Fails a payment.
+      #
+      # Marks a Solidus payment associated to a Stripe payment intent as
+      # failed, adding a log entry about the event.
+      #
+      # @param event [SolidusStripe::Webhook::Event]
+      def fail_payment(event)
+        payment = extract_payment_from_event(event)
+        return if payment.failed?
+
+        payment.failure!.tap do
+          SolidusStripe::LogEntries.payment_log(
+            payment,
+            success: false,
+            message: "Payment was marked as failed after payment_intent.failed webhook"
+          )
+        end
+      end
+
+      private
+
+      def extract_payment_from_event(event)
+        payment_intent_id = event.data.object.id
+        Spree::Payment.find_by!(response_code: payment_intent_id)
       end
     end
   end

--- a/lib/solidus_stripe/webhook/event.rb
+++ b/lib/solidus_stripe/webhook/event.rb
@@ -15,6 +15,7 @@ module SolidusStripe
 
       CORE_EVENTS = Set[*%i[
         payment_intent.succeeded
+        payment_intent.payment_failed
       ]].freeze
       private_constant :CORE_EVENTS
 

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/payment_failed_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/payment_failed_spec.rb
@@ -1,0 +1,23 @@
+require "solidus_stripe_spec_helper"
+
+RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
+  describe "POST /create payment_intent.payment_failed" do
+    it "transitions the associated payment to failed" do
+      payment_method = create(:stripe_payment_method)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      payment = create(:payment,
+        payment_method: payment_method,
+        response_code: stripe_payment_intent.id,
+        state: "pending")
+      context = SolidusStripe::Webhook::EventWithContextFactory.from_object(
+        payment_method: payment_method,
+        object: stripe_payment_intent,
+        type: "payment_intent.payment_failed"
+      )
+
+      expect do
+        webhook_request(context)
+      end.to change { payment.reload.state }.from("pending").to("failed")
+    end
+  end
+end

--- a/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
       described_class.new.complete_payment(event)
 
+      details = payment.log_entries.last.parsed_details
+      expect(details.success?).to be(true)
       expect(
-        payment.log_entries.last.parsed_details.message
+        details.message
       ).to eq "Capture was successful after payment_intent.succeeded webhook"
     end
 
@@ -96,8 +98,10 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
       described_class.new.fail_payment(event)
 
+      details = payment.log_entries.last.parsed_details
+      expect(details.success?).to be(false)
       expect(
-        payment.log_entries.last.parsed_details.message
+        details.message
       ).to eq "Payment was marked as failed after payment_intent.failed webhook"
     end
 

--- a/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
@@ -61,4 +61,63 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
       expect(payment.log_entries.count).to be(0)
     end
   end
+
+  describe "#fail_payment" do
+    it "fails a pending payment" do
+      payment_method = create(:stripe_payment_method)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      payment = create(:payment,
+        payment_method: payment_method,
+        response_code: stripe_payment_intent.id,
+        state: "pending")
+      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
+        payment_method: payment_method,
+        object: stripe_payment_intent,
+        type: "payment_intent.payment_failed"
+      ).solidus_stripe_object
+
+      described_class.new.fail_payment(event)
+
+      expect(payment.reload.state).to eq "failed"
+    end
+
+    it "adds a log entry to the payment" do
+      payment_method = create(:stripe_payment_method)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      payment = create(:payment,
+        payment_method: payment_method,
+        response_code: stripe_payment_intent.id,
+        state: "pending")
+      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
+        payment_method: payment_method,
+        object: stripe_payment_intent,
+        type: "payment_intent.payment_failed"
+      ).solidus_stripe_object
+
+      described_class.new.fail_payment(event)
+
+      expect(
+        payment.log_entries.last.parsed_details.message
+      ).to eq "Payment was marked as failed after payment_intent.failed webhook"
+    end
+
+    it "does nothing if the payment is already failed" do
+      payment_method = create(:stripe_payment_method)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      payment = create(:payment,
+        payment_method: payment_method,
+        response_code: stripe_payment_intent.id,
+        state: "failed")
+      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
+        payment_method: payment_method,
+        object: stripe_payment_intent,
+        type: "payment_intent.payment_failed",
+      ).solidus_stripe_object
+
+      described_class.new.fail_payment(event)
+
+      expect(payment.reload.state).to eq "failed"
+      expect(payment.log_entries.count).to be(0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

A `payment_intent.failed` event is [published](https://stripe.com/docs/payments/payment-intents/verifying-status#webhooks) when a payment intent can't be captured from Stripe.

After we check #185, the webhook could also be triggered by an action from the backend, so we need to do nothing if the payment is already failed.

Closes #179

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
