### PR TITLE
Handle payment_intent.canceled event

### DIFF
--- a/lib/solidus_stripe/webhook/event.rb
+++ b/lib/solidus_stripe/webhook/event.rb
@@ -16,6 +16,7 @@ module SolidusStripe
       CORE_EVENTS = Set[*%i[
         payment_intent.succeeded
         payment_intent.payment_failed
+        payment_intent.canceled
       ]].freeze
       private_constant :CORE_EVENTS
 

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/canceled_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/canceled_spec.rb
@@ -1,0 +1,23 @@
+require "solidus_stripe_spec_helper"
+
+RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
+  describe "POST /create payment_intent.canceled" do
+    it "transitions the associated payment to failed" do
+      payment_method = create(:stripe_payment_method)
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
+      payment = create(:payment,
+        payment_method: payment_method,
+        response_code: stripe_payment_intent.id,
+        state: "pending")
+      context = SolidusStripe::Webhook::EventWithContextFactory.from_object(
+        payment_method: payment_method,
+        object: stripe_payment_intent,
+        type: "payment_intent.canceled"
+      )
+
+      expect do
+        webhook_request(context)
+      end.to change { payment.reload.state }.from("pending").to("void")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A `payment_intent.canceled` event is [published](https://stripe.com/docs/api/events/types#event_types-payment_intent.canceled) when canceling a payment intent from the Stripe dashboard. At that point, we need to update the associated Solidus payment to be voided.

However, the webhook could also be received after voiding the payment from the Solidus admin interface, as it updates through Stripe's API. Therefore, we need to do nothing if the payment is already voided.

Closes #181

[1] - https://stripe.com/docs/api/events/types#event_types-payment_intent.canceled

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
