### PR TITLE
Improve payment form handling and start using `@stripe/stripe-js` module

### DIFF
--- a/lib/generators/solidus_stripe/install/install_generator.rb
+++ b/lib/generators/solidus_stripe/install/install_generator.rb
@@ -78,6 +78,8 @@ module SolidusStripe
               template engine.root.join(path), path
             end
           end
+
+          run 'bin/importmap pin @stripe/stripe-js'
         end
       end
 

--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
@@ -1,5 +1,5 @@
-import { Controller } from '@hotwired/stimulus'
-import { loadStripe } from '@stripe/stripe-js'
+import { Controller } from "@hotwired/stimulus"
+import { loadStripe } from "@stripe/stripe-js"
 
 export default class extends Controller {
   static values = {
@@ -15,7 +15,7 @@ export default class extends Controller {
     radioSelector: String,
   }
 
-  static targets = ['paymentElement', 'message']
+  static targets = ["paymentElement", "message"]
 
   get submitOutletElement() {
     return document.querySelector(this.submitSelectorValue)
@@ -32,6 +32,9 @@ export default class extends Controller {
 
   // @action
   async handleSubmit(e) {
+    // Bail out if not on the payment method form.
+    if (e.target !== this.radioOutletElement.form) return
+
     // Bail out if the current payment method is not selected.
     if (!this.radioOutletElement.checked) return
 
@@ -41,10 +44,10 @@ export default class extends Controller {
 
     const { error } = await this.confirmIntent()
 
-    if (error.type === 'card_error' || error.type === 'validation_error') {
+    if (error.type === "card_error" || error.type === "validation_error") {
       this.messageTarget.textContent = error.message
     } else {
-      this.messageTarget.textContent = 'An unexpected error occurred.'
+      this.messageTarget.textContent = "An unexpected error occurred."
     }
 
     this.setLoading(false)
@@ -53,8 +56,8 @@ export default class extends Controller {
   confirmIntent() {
     let confirmMethod
 
-    if (this.flowValue === 'payment') confirmMethod = 'confirmPayment'
-    if (this.flowValue === 'setup') confirmMethod = 'confirmSetup'
+    if (this.flowValue === "payment") confirmMethod = "confirmPayment"
+    if (this.flowValue === "setup") confirmMethod = "confirmSetup"
 
     if (!this.flowValue)
       throw new Error("flowValue should be either 'payment' or 'setup'.")
@@ -69,11 +72,11 @@ export default class extends Controller {
 
   setupPaymentElement() {
     this.elements = this.stripe.elements({
-      appearance: { theme: 'stripe' },
+      appearance: { theme: "stripe" },
       clientSecret: this.clientSecretValue,
     })
-    this.paymentElement = this.elements.create('payment', { layout: 'tabs' })
-    this.paymentElementTarget.innerHTML = '' // Remove child nodes used for loading
+    this.paymentElement = this.elements.create("payment", { layout: "tabs" })
+    this.paymentElementTarget.innerHTML = "" // Remove child nodes used for loading
     this.paymentElement.mount(this.paymentElementTarget)
   }
 
@@ -81,9 +84,9 @@ export default class extends Controller {
     const element = this.submitOutletElement
 
     if (isLoading) {
-      element.setAttribute('disabled', '')
+      element.setAttribute("disabled", "")
     } else {
-      element.removeAttribute('disabled')
+      element.removeAttribute("disabled")
     }
   }
 }

--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_intent_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { loadStripe } from '@stripe/stripe-js'
 
 export default class extends Controller {
   static values = {
@@ -24,8 +25,8 @@ export default class extends Controller {
     return document.querySelector(this.radioSelectorValue)
   }
 
-  connect() {
-    this.stripe = Stripe(this.publishableKeyValue)
+  async connect() {
+    this.stripe = await loadStripe(this.publishableKeyValue)
     this.setupPaymentElement()
   }
 

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -1,5 +1,3 @@
-<script src="https://js.stripe.com/v3/"></script>
-
 <% intent = payment_method.intent_for_order(current_order) %>
 
 <div


### PR DESCRIPTION
## Summary

Extracted from #249 

Use the [@stripe/stripe-js](https://www.npmjs.com/package/@stripe/stripe-js) module with `importmap`, as partially described in the [Stripe doc](https://stripe.com/docs/libraries/stripejs-esmodule#web-stripejs-esmodule).

The `<script>` tag is added to every page to support fraud detection as suggested in the stripe-js repo.
We opted for using the script tag instead of relying on the implicit side-effect because the browser will be able to start loading it earlier if it's directly in the HTML.

https://github.com/stripe/stripe-js#ensuring-stripejs-is-available-everywhere

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
