### PR TITLE
Remove support for Ruby v2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,13 @@ jobs:
           path: /home/circleci/project/coverage/
           destination: coverage
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    parameters:
+      ruby:
+        type: string
+        default: "3.2"
+    executor:
+      name: solidusio_extensions/sqlite-memory
+      ruby_version: << parameters.ruby >>
     steps:
       - solidusio_extensions/lint-code
       - run:
@@ -105,4 +111,5 @@ workflows:
               ruby: ["3.2"] # TODO: ['3.2', '3.1', '3.0']
               database: ["sqlite"] # TODO: ['mysql', 'sqlite', 'postgres']
               coverage: [true]
-      - lint-code
+      - lint-code:
+          ruby: "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 
 AllCops:
   NewCops: disable
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '3.0'
   Exclude:
     - sandbox/**/*
     - dummy-app/**/*

--- a/solidus_stripe.gemspec
+++ b/solidus_stripe.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_stripe'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_stripe/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary

Ruby v2.7 will reach EOL on 2023-03-31, so we'll be removing support on Solidus very soon.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
