### PR TITLE
Support `auto_capture` for the Stripe payment method

### DIFF
--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -35,6 +35,9 @@ module SolidusStripe
       when 'requires_capture'
         payment.pend! unless payment.pending?
         successful = true
+      when 'succeeded'
+        payment.complete! unless payment.completed?
+        successful = true
       else
         payment.failure!
         successful = false
@@ -81,7 +84,7 @@ module SolidusStripe
             order.currency,
           ),
           currency: order.currency,
-          capture_method: 'manual',
+          capture_method: payment_method.auto_capture? ? 'automatic' : 'manual',
           setup_future_usage: payment_method.preferred_setup_future_usage.presence,
           customer: stripe_customer_id,
           metadata: { solidus_order_number: order.number },

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -6,6 +6,7 @@
   ),
   currency: current_order.currency.downcase,
   paymentMethodCreation: 'manual',
+  captureMethod: payment_method.auto_capture? ? 'automatic' : 'manual',
   # Fully customizable with appearance API.
   # https://stripe.com/docs/elements/appearance-api
   # appearance: {},

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe 'SolidusStripe Checkout', :js do
     end
   end
 
+  context 'when auto-capture is enabled' do
+    it 'creates a payment intent and automatically processes payment' do
+      creates_payment_method(auto_capture: true)
+
+      successfully_creates_a_payment_intent(user: create(:user), auto_capture: true)
+    end
+  end
+
   context 'with a registered user' do
     ['on_session', 'off_session'].each do |setup_future_usage|
       context "when setup_future_usage is set with '#{setup_future_usage}'" do


### PR DESCRIPTION
## Summary

- [x] #249

Fixes https://github.com/solidusio/solidus_stripe/issues/178

With this PR, the Solidus auto-capture feature has been incorporated into the Stripe integration through the use of the auto_capture flag in the `Spree::PaymentMethod` base model.
Stripe `capture_method` is now auto-configured during the intent creation with "manual" or "automatic" based on the auto_capture flag in the related payment method.

More information can be found in the Stripe documentation:
https://stripe.com/docs/api/payment_intents/object#payment_intent_object-capture_method

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
