### PR TITLE
Add support for Store Credits

### DIFF
--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -80,7 +80,7 @@ module SolidusStripe
       payment_method.gateway.request do
         Stripe::PaymentIntent.create({
           amount: payment_method.gateway.to_stripe_amount(
-            order.display_total.money.fractional,
+            order.display_order_total_after_store_credit.money.fractional,
             order.currency,
           ),
           currency: order.currency,

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -1,7 +1,7 @@
 <% payment_element_options = {
   mode: 'payment',
   amount: SolidusStripe::MoneyToStripeAmountConverter.to_stripe_amount(
-    current_order.display_total.money.fractional,
+    current_order.display_order_total_after_store_credit.money.fractional,
     current_order.currency,
   ),
   currency: current_order.currency.downcase,

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -220,6 +220,13 @@ module SolidusStripe::CheckoutTestHelper
     expect(page).to have_no_selector("[name='order[wallet_payment_source_id]']")
   end
 
+  def expects_to_have_specific_authorized_amount_on_stripe(amount)
+    stripe_payment_intent = payment_method.gateway.request do
+      Stripe::PaymentIntent.retrieve(last_stripe_payment.response_code)
+    end
+    expect(stripe_payment_intent.amount).to eq(amount * 100)
+  end
+
   # Test methods
   #
   # These are methods that are used specifically for testing the Stripe

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -36,8 +36,16 @@ module SolidusStripe::CheckoutTestHelper
     @payment_method ||= SolidusStripe::PaymentMethod.first!
   end
 
+  def current_order
+    @current_order ||= Spree::Order.last!
+  end
+
+  def last_stripe_payment
+    current_order.payments.reorder(id: :desc).find_by(source_type: "SolidusStripe::PaymentSource")
+  end
+
   def captures_last_valid_payment
-    payment = Spree::Payment.valid.last
+    payment = current_order.payments.valid.last
     payment.capture!
     expect(payment.payment_method.type).to eq('SolidusStripe::PaymentMethod')
     intent = payment.payment_method.gateway.request do
@@ -165,12 +173,12 @@ module SolidusStripe::CheckoutTestHelper
   # the checkout process.
 
   def visits_payment_step(user: nil)
-    order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
+    @current_order = Spree::TestingSupport::OrderWalkthrough.up_to(:delivery, user: user)
 
     if user
-      sign_in order.user
+      sign_in current_order.user
     else
-      assigns_guest_token order.guest_token
+      assigns_guest_token current_order.guest_token
     end
 
     visit '/checkout/payment'
@@ -201,11 +209,11 @@ module SolidusStripe::CheckoutTestHelper
 
   def moves_order_back_to_payment
     expect(page).to have_current_path('/checkout/payment')
-    expect(Spree::Order.last.state).to eq('payment')
+    expect(current_order.state).to eq('payment')
   end
 
   def fails_the_payment
-    expect(Spree::Payment.last.state).to eq('failed')
+    expect(last_stripe_payment.state).to eq('failed')
   end
 
   def expects_page_to_not_display_wallet_payment_sources
@@ -218,10 +226,9 @@ module SolidusStripe::CheckoutTestHelper
   # checkout process.
 
   def payment_intent_is_created_with_required_capture
-    order = Spree::Order.last
     intent = SolidusStripe::PaymentIntent.where(
       payment_method: payment_method,
-      order: order
+      order: current_order
     ).last.stripe_intent
     expect(intent.status).to eq('requires_capture')
   end
@@ -236,10 +243,9 @@ module SolidusStripe::CheckoutTestHelper
   end
 
   def payment_intent_is_created_with_required_action
-    order = Spree::Order.last
     intent = SolidusStripe::PaymentIntent.where(
       payment_method: payment_method,
-      order: order
+      order: current_order
     ).last.stripe_intent
     expect(intent.status).to eq('requires_action')
   end

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe 'SolidusStripe Checkout', :js do
   end
 
   context 'with a registered user' do
+    it 'successfully processes payment using available store credits' do
+      create(:store_credit_payment_method)
+      creates_payment_method
+      user = create(:user)
+      store_credit_amount = 5
+      create(:store_credit, user: user, amount: store_credit_amount)
+
+      successfully_creates_a_payment_intent(user: user)
+
+      expects_to_have_specific_authorized_amount_on_stripe(current_order.total - store_credit_amount)
+    end
+
     ['on_session', 'off_session'].each do |setup_future_usage|
       context "when setup_future_usage is set with '#{setup_future_usage}'" do
         before { creates_payment_method(setup_future_usage: setup_future_usage) }


### PR DESCRIPTION
## Summary

- [x] #249

Fixes #198

This PR adds functionality to support the use of store credits when processing payments through the Stripe payment method.
Specifically, the initialization of the Stripe elements and the creation of payment intents have been updated to ensure that the correct `amount` is charged to the user, considering any available store credits applied to the related order.

## Note

- What happens if store credits fully cover the order?
The Solidus Stripe Payment will be correctly invalidated, and no payment intents will be created on Stripe (same in case of using  a `SolidusStripe::PaymentSource`)
<img width="1094" alt="Screenshot 2023-03-30 at 14 57 05" src="https://user-images.githubusercontent.com/19948291/228843556-4394527f-15e1-4daf-ad10-fd9b682a9f46.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
