### PR TITLE
Handle partial captures

### DIFF
--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -20,6 +20,15 @@ module SolidusStripe
 
     delegate :slug, to: :slug_entry
 
+    # @return [Spree::RefundReason] the reason used for refunds
+    #   generated from Stripe.
+    # @see SolidusStripe::Configuration.refund_reason_name
+    def self.refund_reason
+      Spree::RefundReason.find_by!(
+        name: SolidusStripe.configuration.refund_reason_name
+      )
+    end
+
     def partial_name
       "stripe"
     end

--- a/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
@@ -43,7 +43,7 @@ module SolidusStripe
           payment: payment,
           amount: amount,
           transaction_id: payment_intent_id,
-          reason: default_refund_reason
+          reason: SolidusStripe::PaymentMethod.refund_reason
         ).tap do
           SolidusStripe::LogEntries.payment_log(
             payment,
@@ -54,12 +54,6 @@ module SolidusStripe
       end
 
       private
-
-      def default_refund_reason
-        Spree::RefundReason.find_by!(
-          name: SolidusStripe.configuration.refund_reason_name
-        )
-      end
 
       def refund_amount(new_stripe_total, currency, payment)
         last_total = payment.refunds.sum(:amount)

--- a/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require "solidus_stripe/money_to_stripe_amount_converter"
+
 module SolidusStripe
   module Webhook
     # Handlers for Stripe payment_intent events.
     class PaymentIntentSubscriber
       include Omnes::Subscriber
+      include SolidusStripe::MoneyToStripeAmountConverter
 
-      handle :"stripe.payment_intent.succeeded", with: :complete_payment
+      handle :"stripe.payment_intent.succeeded", with: :capture_payment
       handle :"stripe.payment_intent.payment_failed", with: :fail_payment
       handle :"stripe.payment_intent.canceled", with: :void_payment
 
@@ -15,17 +18,26 @@ module SolidusStripe
       # Marks a Solidus payment associated to a Stripe payment intent as
       # completed, adding a log entry about the event.
       #
+      # In the case of a partial capture, a refund is created for the
+      # remaining amount and a log entry is added.
+      #
       # @param event [SolidusStripe::Webhook::Event]
-      def complete_payment(event)
+      def capture_payment(event)
         payment = extract_payment_from_event(event)
         return if payment.completed?
 
-        payment.complete!.tap do
-          SolidusStripe::LogEntries.payment_log(
-            payment,
-            success: true,
-            message: "Capture was successful after payment_intent.succeeded webhook"
-          )
+        event.data.object.to_hash => {
+          amount: stripe_amount,
+          amount_received: stripe_amount_received,
+          currency:
+        }
+        if stripe_amount == stripe_amount_received
+          complete_payment(payment)
+        else
+          payment.transaction do
+            complete_payment(payment)
+            refund_payment(payment, stripe_amount, stripe_amount_received, currency)
+          end
         end
       end
 
@@ -73,6 +85,38 @@ module SolidusStripe
       def extract_payment_from_event(event)
         payment_intent_id = event.data.object.id
         Spree::Payment.find_by!(response_code: payment_intent_id)
+      end
+
+      def complete_payment(payment)
+        payment.complete!.tap do
+          SolidusStripe::LogEntries.payment_log(
+            payment,
+            success: true,
+            message: "Capture was successful after payment_intent.succeeded webhook"
+          )
+        end
+      end
+
+      def refund_payment(payment, stripe_amount, stripe_amount_received, currency)
+        refunded_amount = decimal_amount(stripe_amount - stripe_amount_received, currency)
+        Spree::Refund.create!(
+          payment: payment,
+          amount: refunded_amount,
+          transaction_id: payment.response_code,
+          reason: SolidusStripe::PaymentMethod.refund_reason
+        ).tap do
+          SolidusStripe::LogEntries.payment_log(
+            payment,
+            success: true,
+            message: "Payment was refunded after payment_intent.succeeded webhook (#{_1.money})"
+          )
+        end
+      end
+
+      def decimal_amount(stripe_amount, currency)
+        stripe_amount
+          .then { to_solidus_amount(_1, currency) }
+          .then { solidus_subunit_to_decimal(_1, currency) }
       end
     end
   end

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/succeeded_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/succeeded_spec.rb
@@ -2,10 +2,16 @@ require "solidus_stripe_spec_helper"
 
 RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
   describe "POST /create payment_intent.succeeded" do
-    it "transitions the associated payment to completed" do
+    it "captures the associated payment" do
       payment_method = create(:stripe_payment_method)
-      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(
+        id: "pi_123",
+        amount: 1000,
+        amount_received: 1000,
+        currency: "usd"
+      )
       payment = create(:payment,
+        amount: 10,
         payment_method: payment_method,
         response_code: stripe_payment_intent.id,
         state: "pending")


### PR DESCRIPTION
## Summary

Stripe allows for a payment to be [partially captured](http://localhost:3000/checkout/confirm), creating a refund for the remaining amount.

We're now acting accordingly by changing how we handle the `payment_intent.succeeded` webhook. When the capture is total, we do as before. For partial captures, on top of the latter, we create a Solidus refund for the uncaptured amount.

Closes #221

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
