### PR TITLE
Add missing API source payment partial view for Stripe payment sources

### DIFF
--- a/app/views/spree/api/payments/source_views/_stripe.json.jbuilder
+++ b/app/views/spree/api/payments/source_views/_stripe.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+attrs = [:id]
+if @current_user_roles.include?("admin")
+  attrs += [:stripe_payment_method_id]
+end
+
+json.call(payment_source, *attrs)


### PR DESCRIPTION
## Summary

Fixes #251

This PR resolves an issue where a missing partial for the Stripe payment source was causing an exception during the order
API GET call in solidus_backend.
The new payment view is added to render payment source data as JSON.

For more details in `solidusio/solidus`:
https://github.com/solidusio/solidus/blob/e878076f2ed670d07654ab6293a16588743f2fa6/api/app/views/spree/api/orders/_big.json.jbuilder#L36-L43

Refer to this comment for more details about the mentioned exception:
https://github.com/solidusio/solidus_stripe/issues/251#issuecomment-1485187657

**Before**
![Screenshot](https://user-images.githubusercontent.com/19948291/227965795-81c421c2-7f30-46cd-b701-d4c1685c852d.png)
**After**
![Screenshot 2023-03-31 at 17 32 20](https://user-images.githubusercontent.com/19948291/229164868-f89db622-67d9-459f-8073-fa68a4c2bc68.png)

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
