### PR TITLE
Add caching support to sandbox apps creation

### DIFF
--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -3,27 +3,15 @@
 set -e
 
 extension_name="solidus_stripe"
+app_name="dummy-app"
+
+bin/rails-new "$app_name"
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {
-  ruby -rbundler -e'Bundler.with_unbundled_env{system({"BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES"=>"1"},*ARGV)}' -- "$@"
+  echo "~~> Running: $@"
+  ruby -rbundler -e'Bundler.with_unbundled_env {system *ARGV}' -- env BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true "$@"
 }
-
-# "sqlite" is set by the ORB extension instead of "sqlite3",
-# all other options are already in the format expected by `rails new`.
-test "$DB" = "sqlite" && export DB="sqlite3"
-
-rm -rf ./dummy-app
-rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new dummy-app \
-  --database=${DB:-sqlite3} \
-  --skip-git \
-  --skip-rc
-
-if [ ! -d "dummy-app" ]; then
-  echo 'dummy-app rails application failed'
-  exit 1
-fi
 
 cd ./dummy-app
 
@@ -39,4 +27,3 @@ unbundled bundle exec rake db:drop db:create
 unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..
 unbundled bundle exec rails generate $extension_name:install --migrate --load-seeds=false --specs=all
-

--- a/bin/rails-new
+++ b/bin/rails-new
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+app_name="$1"
+
+root_path="$PWD"
+app_path="${root_path}/${app_name}"
+ruby_version=`ruby -e'puts RUBY_VERSION'`
+rails_version=`bundle exec ruby -rrails/version -e'puts Rails.version'`
+solidus_version=`bundle exec ruby -rspree/core/version -e'puts Spree::VERSION'`
+cache_path="tmp/cache/rails-new/${app_name}-${rails_version}-${solidus_version}-${ruby_version}.zip"
+
+# Stay away from the bundler env of the containing extension.
+function unbundled {
+  echo "~~> Running: $@"
+  ruby -rbundler -e'Bundler.with_unbundled_env {system *ARGV}' -- env BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true "$@"
+}
+
+# "sqlite" is set by the ORB extension instead of "sqlite3",
+# all other options are already in the format expected by `rails new`.
+test "$DB" = "sqlite" && export DB="sqlite3"
+
+rm -rf "$app_path"
+mkdir -p tmp/cache/rails-new
+
+if [ -f "${cache_path}" ]; then
+  echo "~~> Using cached rails ${app_name}"
+  unzip -q "${cache_path}" -d ./
+  cd "${app_path}"
+  unbundled bundle install
+  cd "${root_path}"
+else
+  echo "~~> Creating rails ${app_name}"
+  rails _${rails_version}_ new ${app_name} \
+    --database=${DB:-sqlite3} \
+    --skip-git \
+    --skip-rc
+
+  cd "$app_path"
+  unbundled bundle add listen --group development
+  unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
+  unbundled bundle exec rake db:drop db:create
+  unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none
+  cd "${root_path}"
+
+  echo "~~> Creating rails ${app_name} cache"
+  rm -rf ${app_name}/tmp/solidus_starter_frontend*
+  zip -q -r "${cache_path}" ${app_name}
+fi
+
+if [ ! -d "${app_name}" ]; then
+  echo '~~> Creation of the ${app_name} rails application failed'
+  exit 1
+fi

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -3,33 +3,17 @@
 set -e
 
 extension_name="solidus_stripe"
+app_name="sandbox"
+
+bin/rails-new "$app_name"
 
 # Stay away from the bundler env of the containing extension.
 function unbundled {
-  ruby -rbundler -e'b = proc {system *ARGV}; Bundler.respond_to?(:with_unbundled_env) ? Bundler.with_unbundled_env(&b) : Bundler.with_clean_env(&b)' -- "$@"
+  echo "~~> Running: $@"
+  ruby -rbundler -e'Bundler.with_unbundled_env {system *ARGV}' -- env BUNDLE_SUPPRESS_INSTALL_USING_MESSAGES=true "$@"
 }
 
-# "sqlite" is set by the ORB extension instead of "sqlite3",
-# all other options are already in the format expected by `rails new`.
-test "$DB" = "sqlite" && export DB="sqlite3"
-
-rm -rf ./sandbox
-rails_version=`bundle exec ruby -e'require "rails"; puts Rails.version'`
-rails _${rails_version}_ new sandbox \
-  --database=${DB:-sqlite3} \
-  --skip-git \
-  --skip-rc
-
-if [ ! -d "sandbox" ]; then
-  echo '~~> Creation of the sandbox rails application failed'
-  exit 1
-fi
-
-cd ./sandbox
-unbundled bundle add listen --group development
-unbundled bundle add solidus --github solidusio/solidus --branch "${BRANCH:-master}" --version '> 0.a'
-unbundled bundle exec rake db:drop db:create
-unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none "$@"
+cd "./$app_name"
 unbundled bundle add $extension_name --path ..
 unbundled bundle exec rails generate $extension_name:install --migrate --specs=all
 


### PR DESCRIPTION

## Summary

With a warm cache the sandbox app creation goes from ~130s to ~30s on my Apple M1.

The optimization is used for the dummy-app creation as well.
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
