### PR TITLE
Allow reuse of payment sources via admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ the following partial should be added:
 IBAN: **** **** **** **** **** <%= sepa_debit.last4 %>
 ```
 
+### Showing reusable sources in the admin interface
+
+Refer to the previous section for information on how to set up a new payment method type.
+However, it's important to note that if you have to display a wallet source connected to a
+Stripe Payment Method other than "card" on the admin interface, you must include the partial in:
+
+`app/views/spree/admin/payments/source_forms/existing_payment/stripe/`
+
 ### Custom webhooks
 
 You can also use [Stripe webhooks](https://stripe.com/docs/webhooks) to trigger

--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -31,6 +31,44 @@ module SolidusStripe
 
     attr_reader :client
 
+    # Authorizes a certain amount on the provided payment source.
+    #
+    # We create and confirm the Stripe payment intent in two steps. That's to
+    # guarantee that we associate a Solidus payment on the creation, and we can
+    # fetch it after the webhook event is published on confirmation.
+    #
+    # The Stripe payment intent id is copied over the Solidus payment
+    # `response_code` field.
+    def authorize(amount_in_cents, _source, options = {})
+      check_given_amount_matches_payment_intent(amount_in_cents, options)
+
+      stripe_payment_intent_options = {
+        amount: to_stripe_amount(amount_in_cents, options[:originator].currency),
+        confirm: false,
+        capture_method: "manual",
+      }
+
+      stripe_payment_intent = SolidusStripe::PaymentIntent.prepare_for_payment(
+        options[:originator],
+        **stripe_payment_intent_options,
+      )
+
+      confirm_stripe_payment_intent(stripe_payment_intent.stripe_intent_id)
+
+      build_payment_log(
+        success: true,
+        message: "PaymentIntent was confirmed successfully",
+        response_code: stripe_payment_intent.stripe_intent_id,
+        data: stripe_payment_intent.stripe_intent
+      )
+    rescue Stripe::StripeError => e
+      build_payment_log(
+        success: false,
+        message: e.message,
+        data: e.response
+      )
+    end
+
     # Captures a certain amount from a previously authorized transaction.
     #
     # @see https://stripe.com/docs/api/payment_intents/capture#capture_payment_intent
@@ -49,6 +87,41 @@ module SolidusStripe
         data: payment_intent,
       )
     rescue Stripe::InvalidRequestError => e
+      build_payment_log(
+        success: false,
+        message: e.to_s,
+        data: e.response,
+      )
+    end
+
+    # Authorizes and captures a certain amount on the provided payment source.
+    #
+    # See `#authorize` for how the confirmation step is performed.
+    #
+    # @todo add support for purchasing custom amounts
+    def purchase(amount_in_cents, _source, options = {})
+      check_given_amount_matches_payment_intent(amount_in_cents, options)
+
+      stripe_payment_intent_options = {
+        amount: to_stripe_amount(amount_in_cents, options[:originator].currency),
+        confirm: false,
+        capture_method: "automatic",
+      }
+
+      stripe_payment_intent = SolidusStripe::PaymentIntent.prepare_for_payment(
+        options[:originator],
+        **stripe_payment_intent_options,
+      )
+
+      confirm_stripe_payment_intent(stripe_payment_intent.stripe_intent_id)
+
+      build_payment_log(
+        success: true,
+        message: "PaymentIntent was confirmed and captured successfully",
+        response_code: stripe_payment_intent.stripe_intent_id,
+        data: stripe_payment_intent.stripe_intent,
+      )
+    rescue Stripe::StripeError => e
       build_payment_log(
         success: false,
         message: e.to_s,
@@ -125,6 +198,10 @@ module SolidusStripe
     end
 
     private
+
+    def confirm_stripe_payment_intent(stripe_payment_intent_id)
+      request { Stripe::PaymentIntent.confirm(stripe_payment_intent_id) }
+    end
 
     def capture_stripe_payment_intent(stripe_payment_intent_id)
       request { Stripe::PaymentIntent.capture(stripe_payment_intent_id) }

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -82,5 +82,25 @@ module SolidusStripe
 
       create_slug_entry!(slug: slug)
     end
+
+    # The method that should be used is "Spree::PaymentMethod#reusable_sources".
+    # However, in the dedicated partial source form, the reusable_sources are
+    # assigned to "previous_cards":
+    # https://github.com/solidusio/solidus/blob/e9debb976e2228bb0b7a8eff4894e0556fc15cc8/backend/app/views/spree/admin/payments/_form.html.erb#L31
+    # This name is inaccurate and too specific because, in our case, a
+    # payment-source/stripe-payment-method have many different possible types:
+    # https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+    #
+    # For more details:
+    # https://github.com/solidusio/solidus/issues/5014
+    #
+    # @todo Start using the correct method to get a user's previous sources
+    def previous_sources(order)
+      if order.user_id
+        order.user.wallet.wallet_payment_sources.map(&:payment_source)
+      else
+        []
+      end
+    end
   end
 end

--- a/app/models/solidus_stripe/payment_method.rb
+++ b/app/models/solidus_stripe/payment_method.rb
@@ -11,7 +11,6 @@ module SolidusStripe
     # @see https://stripe.com/docs/webhooks/signatures
     preference :webhook_endpoint_signing_secret, :string
 
-    validates :available_to_admin, inclusion: { in: [false] }
     validates :preferred_setup_future_usage, inclusion: { in: ['', 'on_session', 'off_session'] }
 
     has_one :slug_entry, class_name: 'SolidusStripe::SlugEntry', inverse_of: :payment_method, dependent: :destroy

--- a/app/views/spree/admin/payments/source_forms/_stripe.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_stripe.html.erb
@@ -1,0 +1,29 @@
+<fieldset>
+  <legend><%= payment_method.name %></legend>
+
+  <% previous_sources = payment_method.previous_sources(@order) %>
+
+  <ul>
+    <% previous_sources.each do |payment_source| %>
+      <% default = payment_source == previous_sources.first %>
+      <% stripe_payment_method = payment_source.stripe_payment_method %>
+
+      <li>
+        <label>
+          <%= radio_button_tag(
+            :card,
+            payment_source.id,
+            default
+          ) %>
+          <%= stripe_payment_method.type.humanize %>
+        </label>
+        <fieldset>
+          <%= render(
+            "spree/admin/payments/source_forms/existing_payment/#{payment_method.partial_name}",
+            stripe_payment_method: stripe_payment_method,
+          ) %>
+        </fieldset>
+      </li>
+    <% end %>
+  </ul>
+</fieldset>

--- a/app/views/spree/admin/payments/source_forms/existing_payment/_stripe.html.erb
+++ b/app/views/spree/admin/payments/source_forms/existing_payment/_stripe.html.erb
@@ -1,0 +1,14 @@
+<%
+  # https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+  partial_base = "spree/admin/payments/source_forms/existing_payment/stripe"
+  payment_type = stripe_payment_method.type
+
+  # Fallback on the default partial if a specialized partial is not available.
+  payment_type = 'default' if lookup_context.find_all("#{partial_base}/_#{payment_type}").none?
+%>
+
+<div>
+  <label>
+    <%= render "#{partial_base}/#{payment_type}", stripe_payment_method: stripe_payment_method %>
+  </label>
+</div>

--- a/app/views/spree/admin/payments/source_forms/existing_payment/stripe/_card.html.erb
+++ b/app/views/spree/admin/payments/source_forms/existing_payment/stripe/_card.html.erb
@@ -1,0 +1,8 @@
+<% card = stripe_payment_method.card %>
+<%#
+  Add credit card logos:
+  https://support.stripe.com/questions/where-to-find-logos-for-accepted-credit-card-types
+%>
+💳 <%= card.brand %>
+<span>∗∗∗∗&nbsp;∗∗∗∗&nbsp;∗∗∗∗&nbsp;<%= card.last4 %>&nbsp;</span>
+(<%= t 'spree.expiration' %>: <%= card.exp_month %>/<%= card.exp_year %>)

--- a/app/views/spree/admin/payments/source_forms/existing_payment/stripe/_default.html.erb
+++ b/app/views/spree/admin/payments/source_forms/existing_payment/stripe/_default.html.erb
@@ -1,0 +1,7 @@
+<% logger.error(
+  %{Can't find a partial for payments with type #{payment_type} } +
+  %{please add a partial named "#{partial_base}/_#{payment_type}.html.erb".}
+) %>
+
+<%= stripe_payment_method.type.humanize %>
+(<%= time_ago_in_words Time.at(stripe_payment_method.created) %>)

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -20,5 +20,5 @@ unbundled bundle exec rails generate $extension_name:install --migrate --specs=a
 if [[ -n "$SOLIDUS_STRIPE_API_KEY" ]]; then
   echo "~~> Creating the stripe payment method using env credentials..."
   unbundled bundle exec rails runner \
-    'p SolidusStripe::PaymentMethod.create!(name: "SolidusStripe", available_to_admin: false, preference_source: "solidus_stripe_env_credentials", position: -1)'
+    'p SolidusStripe::PaymentMethod.create!(name: "SolidusStripe", preference_source: "solidus_stripe_env_credentials", position: -1)'
 fi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,9 +18,3 @@ en:
     models:
       solidus_stripe/payment_source: Solidus Stripe Payment Source
       solidus_stripe/payment_method: Solidus Stripe Payment Method
-    errors:
-      models:
-        solidus_stripe/payment_method:
-          attributes:
-            available_to_admin:
-              inclusion: "is not allowed for the Stripe payment method"

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :stripe_payment_method, class: 'SolidusStripe::PaymentMethod' do
     type { "SolidusStripe::PaymentMethod" }
     name { "Stripe Payment Method" }
-    available_to_admin { false }
     preferences {
       {
         api_key: ENV['SOLIDUS_STRIPE_API_KEY'] ||

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -138,12 +138,19 @@ FactoryBot.define do
     transient do
       amount { 10 }
       payment_method { build(:stripe_payment_method) }
+      stripe_payment_method_id { "pm_#{SecureRandom.uuid.delete('-')}" }
     end
 
     line_items { [build(:line_item, price: amount)] }
 
     after(:create) do |order, evaluator|
-      build(:payment, amount: evaluator.amount, order: order, payment_method: evaluator.payment_method)
+      build(
+        :stripe_payment,
+        amount: evaluator.amount,
+        order: order,
+        payment_method: evaluator.payment_method,
+        stripe_payment_method_id: evaluator.stripe_payment_method_id
+      )
       order.recalculate
     end
   end

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -3,6 +3,84 @@
 require 'solidus_stripe_spec_helper'
 
 RSpec.describe SolidusStripe::Gateway do
+  describe '#authorize' do
+    it 'confirms the Stripe payment' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
+      stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment,
+        amount: 123.45,
+        payment_method: payment_method,
+        stripe_payment_method_id: stripe_payment_method.id)
+      payment = order.payments.last
+
+      allow(Stripe::Customer).to receive(:create).and_return(stripe_customer)
+      [:create, :update, :retrieve].each do |method|
+        allow(Stripe::PaymentIntent).to receive(method).and_return(stripe_payment_intent)
+      end
+      allow(Stripe::PaymentIntent).to receive(:confirm).with(stripe_payment_intent.id).and_return(stripe_payment_intent)
+
+      result = gateway.authorize(123_45, payment.source, currency: 'USD', originator: order.payments.first)
+
+      expect(Stripe::PaymentIntent).to have_received(:update).with(
+        stripe_payment_intent.id,
+        { payment_method: stripe_payment_method.id }
+      )
+
+      expect(Stripe::PaymentIntent).to have_received(:create).with(
+        amount: 123_45,
+        currency: 'USD',
+        capture_method: 'manual',
+        confirm: false,
+        metadata: { solidus_order_number: order.number },
+        customer: "cus_123",
+        setup_future_usage: nil
+      )
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
+      expect(result.params).to eq("data" => '{"id":"pi_123"}')
+      expect(payment.reload.response_code).to eq("pi_123")
+    end
+
+    it 'generates error response on failure' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment,
+        amount: 123.45,
+        payment_method: payment_method,
+        stripe_payment_method_id: stripe_payment_method.id)
+      payment = order.payments.last
+
+      [:create, :update, :retrieve].each do |method|
+        allow(Stripe::PaymentIntent).to receive(method).and_return(stripe_payment_intent)
+      end
+      allow(Stripe::PaymentIntent).to receive(:confirm).with(
+        stripe_payment_intent.id
+      ).and_raise(Stripe::StripeError.new("auth error"))
+
+      result = gateway.authorize(123_45, payment.source, currency: 'USD', originator: order.payments.first)
+
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
+      expect(result.success?).to be(false)
+      expect(result.message).to eq("auth error")
+    end
+
+    it "raises if the given amount doesn't match the order total" do
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+
+      expect { gateway.authorize(10, :source, originator: order.payments.first ) }.to raise_error(
+        /custom amount is not supported/
+      )
+    end
+  end
+
   describe '#capture' do
     it 'captures a pre-authorized Stripe payment' do
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
@@ -80,6 +158,84 @@ RSpec.describe SolidusStripe::Gateway do
       expect { gateway.void("invalid") }.to raise_error(
         ArgumentError,
         /payment intent id has the wrong format/
+      )
+    end
+  end
+
+  describe '#purchase' do
+    it 'authorizes and captures in a single operation' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
+      stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment,
+        amount: 123.45,
+        payment_method: payment_method,
+        stripe_payment_method_id: stripe_payment_method.id)
+      payment = order.payments.last
+
+      allow(Stripe::Customer).to receive(:create).and_return(stripe_customer)
+      [:create, :update, :retrieve].each do |method|
+        allow(Stripe::PaymentIntent).to receive(method).and_return(stripe_payment_intent)
+      end
+      allow(Stripe::PaymentIntent).to receive(:confirm).with(stripe_payment_intent.id).and_return(stripe_payment_intent)
+
+      result = gateway.purchase(123_45, payment.source, currency: 'USD', originator: order.payments.first)
+
+      expect(Stripe::PaymentIntent).to have_received(:update).with(
+        stripe_payment_intent.id,
+        { payment_method: stripe_payment_method.id }
+      )
+
+      expect(Stripe::PaymentIntent).to have_received(:create).with(
+        amount: 123_45,
+        currency: 'USD',
+        capture_method: 'automatic',
+        confirm: false,
+        metadata: { solidus_order_number: order.number },
+        customer: "cus_123",
+        setup_future_usage: nil
+      )
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
+      expect(result.params).to eq("data" => '{"id":"pi_123"}')
+      expect(payment.reload.response_code).to eq("pi_123")
+    end
+
+    it 'generates error response on failure' do
+      stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment,
+        amount: 123.45,
+        payment_method: payment_method,
+        stripe_payment_method_id: stripe_payment_method.id)
+      payment = order.payments.last
+
+      [:create, :update, :retrieve].each do |method|
+        allow(Stripe::PaymentIntent).to receive(method).and_return(stripe_payment_intent)
+      end
+      allow(Stripe::PaymentIntent).to receive(:confirm).with(
+        stripe_payment_intent.id
+      ).and_raise(Stripe::StripeError.new("auth error"))
+
+      result = gateway.purchase(123_45, payment.source, currency: 'USD', originator: order.payments.first)
+
+      expect(Stripe::PaymentIntent).to have_received(:confirm).with("pi_123")
+      expect(result.success?).to be(false)
+      expect(result.message).to eq("auth error")
+    end
+
+    it "raises if the given amount doesn't match the order total" do
+      payment_method = build(:stripe_payment_method)
+      gateway = payment_method.gateway
+      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+
+      expect { gateway.purchase(10, :source, originator: order.payments.first ) }.to raise_error(
+        /custom amount is not supported/
       )
     end
   end

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -73,6 +73,34 @@ RSpec.describe SolidusStripe::PaymentMethod do
     end
   end
 
+  describe '.previous_sources' do
+    it 'finds no sources associated with the order' do
+      payment_method = create(:stripe_payment_method)
+      order = create(:order, user: nil)
+
+      expect(payment_method.previous_sources(order)).to be_empty
+    end
+
+    it 'finds no sources associated with the user' do
+      payment_method = create(:stripe_payment_method)
+      user = create(:user)
+      order = create(:order, user: user)
+
+      expect(payment_method.previous_sources(order)).to be_empty
+    end
+
+    it 'finds sources associated with the user' do
+      payment_source = create(:stripe_payment_source)
+      payment_method = payment_source.payment_method
+      user = create(:user)
+      order = create(:order, user: user.reload)
+
+      user.wallet.add(payment_source)
+
+      expect(payment_method.previous_sources(order)).to eq [payment_source]
+    end
+  end
+
   describe '.assign_slug' do
     it 'generates a "test" slug for the first payment method in test mode' do
       payment_method = build(:stripe_payment_method)

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -7,16 +7,6 @@ RSpec.describe SolidusStripe::PaymentMethod do
     expect(create(:stripe_payment_method)).to be_valid
   end
 
-  it "doesn't allow available_to_admin" do
-    record = described_class.new(available_to_admin: true)
-
-    record.valid?
-
-    expect(
-      record.errors.added?(:available_to_admin, :inclusion, value: true)
-    ).to be(true)
-  end
-
   describe 'Callbacks' do
     describe 'after_create' do
       it 'creates a webhook endpoint' do

--- a/spec/system/backend/solidus_stripe/orders/payments_spec.rb
+++ b/spec/system/backend/solidus_stripe/orders/payments_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe 'SolidusStripe Orders Payments', :js do
       expects_page_to_display_successfully_canceled_order_payment(payment)
       expects_payment_to_be_voided_on_stripe(payment)
     end
+
+    it 'creates new authorized payment and captures it with existing source successfully' do
+      create_payment_method
+      create_order_with_existing_payment_source
+      complete_order_with_existing_payment_source
+      visit_payments_page
+      capture_payment
+      payment = last_valid_payment
+
+      expects_page_to_display_successfully_captured_payment(payment)
+      expects_payment_to_have_correct_capture_amount_on_stripe(payment, payment.amount)
+    end
   end
 
   context 'with failed payment operations' do


### PR DESCRIPTION
## Summary

- Fixes #280
- Fixes #267 

ℹ️  Please refer to #280 for more details about specific implementation decisions.

- [x] Allow the admin to reuse existing payment sources by introducing a dedicated [source form](https://guides.solidus.io/advanced-solidus/payments-and-refunds/#providing-payment-method-partials). 
  This enables the reuse of payment sources within the user's wallet (preventing the use of payment methods that the user has removed from their wallet).
- [x] Re-introduce `authorize` and `purchase` gateway methods


<img width="1465" alt="Screenshot 2023-04-13 at 20 03 09" src="https://user-images.githubusercontent.com/19948291/232013525-2471ac03-5708-4962-95a5-2900e43efbd7.png">


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
