### PR TITLE
Avoid duplicated Solidus refunds

### DIFF
--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "solidus_stripe/money_to_stripe_amount_converter"
+
+module SolidusStripe
+  # Synchronizes refunds from Stripe to Solidus.
+  #
+  # For our use case, Stripe has two ways to inform us about refunds initiated
+  # on their side:
+  #
+  # 1. The `charge.refunded` webhook event, which is triggered when a refund is
+  # explicitly created.
+  # 2. The `payment_intent.succeeded` webhook event, which is triggered when a
+  # payment intent is captured. If the payment intent is captured for less than
+  # the full amount, a refund is automatically created for the remaining amount.
+  #
+  # In both cases, Stripe doesn't tell us which refund was recently created, so
+  # we need to fetch all the refunds for the payment intent and check if any of
+  # them is missing on Solidus. We're using the `transaction_id` field on
+  # `Spree::Refund` to match refunds against Stripe refunds ids. We could think
+  # about only syncing the single refund not present on Solidus, but we need to
+  # acknowledge concurrent partial refunds.
+  #
+  # The `Spree::RefundReason` with `SolidusStripe::Config.refund_reason_name`
+  # as name is used as created refunds' reason.
+  #
+  # Besides, we need to account for refunds created from Solidus admin panel,
+  # which calls the Stripe API. In this case, we need to avoid syncing the
+  # refund back to Solidus on the subsequent webhook, otherwise we would end up
+  # with duplicate records. We're marking those refunds with a metadata field on
+  # Stripe, so we can filter them out (see {Gateway#credit}).
+  class RefundsSynchronizer
+    include MoneyToStripeAmountConverter
+
+    # Metadata key used to mark refunds that shouldn't be synced back to Solidus.
+    # @return [Symbol]
+    SKIP_SYNC_METADATA_KEY = :solidus_skip_sync
+
+    # Metadata value used to mark refunds that shouldn't be synced back to Solidus.
+    # @return [String]
+    SKIP_SYNC_METADATA_VALUE = 'true'
+
+    # @param payment_method [SolidusStripe::PaymentMethod]
+    def initialize(payment_method)
+      @payment_method = payment_method
+    end
+
+    # @param payment_intent_id [String]
+    def call(payment_intent_id)
+      payment = Spree::Payment.find_by!(response_code: payment_intent_id)
+
+      stripe_refunds(payment_intent_id)
+        .select(&method(:stripe_refund_needs_sync?))
+        .map(
+          &method(:create_refund).curry[payment]
+        )
+    end
+
+    private
+
+    def stripe_refunds(payment_intent_id)
+      @payment_method.gateway.request do
+        Stripe::Refund.list(payment_intent: payment_intent_id).data
+      end
+    end
+
+    def stripe_refund_needs_sync?(refund)
+      originated_outside_solidus = refund.metadata[SKIP_SYNC_METADATA_KEY] != SKIP_SYNC_METADATA_VALUE
+      not_already_synced = Spree::Refund.find_by(transaction_id: refund.id).nil?
+
+      originated_outside_solidus && not_already_synced
+    end
+
+    def create_refund(payment, refund)
+      Spree::Refund.create!(
+        payment: payment,
+        amount: refund_decimal_amount(refund),
+        transaction_id: refund.id,
+        reason: SolidusStripe::PaymentMethod.refund_reason
+      ).tap(&method(:log_refund).curry[payment])
+    end
+
+    def log_refund(payment, refund)
+      SolidusStripe::LogEntries.payment_log(
+        payment,
+        success: true,
+        message: "Payment was refunded after Stripe event (#{refund.money})"
+      )
+    end
+
+    def refund_decimal_amount(refund)
+      to_solidus_amount(refund.amount, refund.currency)
+        .then { |amount| solidus_subunit_to_decimal(amount, refund.currency) }
+    end
+  end
+end

--- a/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
+++ b/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
@@ -1,0 +1,238 @@
+# frozen-string-literal: true
+
+require "solidus_stripe_spec_helper"
+require "solidus_stripe/refunds_synchronizer"
+require "solidus_stripe/seeds"
+
+RSpec.describe SolidusStripe::RefundsSynchronizer do
+  def mock_refund_list(payment_intent_id, refunds)
+    allow(Stripe::Refund).to receive(:list).with(payment_intent: payment_intent_id).and_return(
+      Stripe::ListObject.construct_from(
+        data: refunds
+      )
+    )
+  end
+
+  describe "#call" do
+    let(:payment_method) { create(:stripe_payment_method) }
+
+    it "creates missing refunds on Solidus" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.refunds.count).to eq(1)
+    end
+
+    it "uses the stripe refund id as created Solidus refund transaction_id field" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      refund = payment.refunds.first
+      expect(refund.transaction_id).to eq("re_123")
+    end
+
+    it "uses the stripe amount as created Solidus refund amount" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      refund = payment.refunds.first
+      expect(refund.amount).to eq(10)
+    end
+
+    it "uses the configured reason for created Solidus refunds" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      refund = payment.refunds.first
+      expect(refund.reason).to eq(SolidusStripe::PaymentMethod.refund_reason)
+    end
+
+    it "skips the creation of Solidus refunds with transaction_id matching some stripe refund id" do
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+      create(:refund, amount: 10, payment: payment, transaction_id: "re_123")
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.refunds.count).to be(1)
+    end
+
+    it "skips the creation of Solidus refunds when specified in their metadata" do
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {
+            solidus_skip_sync: 'true'
+          }
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.refunds.count).to be(0)
+    end
+
+    it "creates multiple Solidus refunds if needed" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 500,
+          currency: "usd",
+          metadata: {}
+        },
+        {
+          id: "re_456",
+          amount: 500,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.refunds.count).to be(2)
+    end
+
+    it "creates only the missing Solidus refunds when there're multiple Stripe refunds" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 500,
+          currency: "usd",
+          metadata: {}
+        },
+        {
+          id: "re_456",
+          amount: 500,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+      create(:refund, amount: 5, payment: payment, transaction_id: "re_123")
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.refunds.pluck(:transaction_id)).to contain_exactly("re_123", "re_456")
+    end
+
+    it "adds a log entry for created Solidus refund" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(payment.log_entries.count).to eq(1)
+    end
+
+    it "sets created log entry as successful" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 1000,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(
+        payment.log_entries.first.parsed_details.success?
+      ).to be(true)
+    end
+
+    it "uses a meaningful message with the refunded amount in created log entry" do
+      SolidusStripe::Seeds.refund_reasons
+      payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_refund_list(payment_intent_id, [
+        {
+          id: "re_123",
+          amount: 500,
+          currency: "usd",
+          metadata: {}
+        }
+      ])
+
+      described_class.new(payment_method).call(payment_intent_id)
+
+      expect(
+        payment.log_entries.first.parsed_details.message
+      ).to include("after Stripe event ($5.00)")
+    end
+  end
+end

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe SolidusStripe::Gateway do
     it 'refunds when provided an originator payment' do
       gateway = build(:stripe_payment_method).gateway
       payment = instance_double(Spree::Payment, response_code: 'pi_123', currency: "USD")
-      refund = instance_double(Stripe::Refund, to_json: '{foo: "re_123"}')
+      refund = Stripe::Refund.construct_from(id: "re_123")
       allow(Stripe::Refund).to receive(:create).and_return(refund)
 
       result = gateway.credit(123_45, 'pi_123', currency: 'USD', originator: instance_double(
@@ -99,8 +99,9 @@ RSpec.describe SolidusStripe::Gateway do
       expect(Stripe::Refund).to have_received(:create).with(
         payment_intent: 'pi_123',
         amount: 123_45,
+        metadata: { solidus_skip_sync: 'true' }
       )
-      expect(result.params).to eq("data" => '{foo: "re_123"}')
+      expect(result.params).to eq("data" => '{"id":"re_123"}')
     end
 
     it "raises if no payment_intent_id is given" do

--- a/spec/requests/solidus_stripe/webhooks_controller/charge/refunded_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/charge/refunded_spec.rb
@@ -2,7 +2,7 @@ require "solidus_stripe_spec_helper"
 
 RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
   describe "POST /create charge.refunded" do
-    it "creates a refund for the given payment" do
+    it "synchronizes refunds" do
       SolidusStripe::Seeds.refund_reasons
       payment_method = create(:stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
@@ -11,8 +11,12 @@ RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_reque
         payment_method: payment_method,
         response_code: stripe_payment_intent.id,
         state: "completed")
-      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123", amount_refunded: 500,
-        currency: 'usd')
+      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123")
+      allow(Stripe::Refund).to receive(:list).with(payment_intent: stripe_payment_intent.id).and_return(
+        Stripe::ListObject.construct_from(
+          data: [{ id: "re_123", amount: 1000, currency: "usd", metadata: {} }]
+        )
+      )
       context = SolidusStripe::Webhook::EventWithContextFactory.from_object(
         payment_method: payment_method,
         object: stripe_charge,

--- a/spec/subscribers/solidus_stripe/webhook/charge_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/charge_subscriber_spec.rb
@@ -3,8 +3,8 @@
 require "solidus_stripe_spec_helper"
 
 RSpec.describe SolidusStripe::Webhook::ChargeSubscriber do
-  describe "#refund_payment" do
-    it "creates a refund for a given payment" do
+  describe "#sync_refunds" do
+    it "synchronizes refunds" do
       SolidusStripe::Seeds.refund_reasons
       payment_method = create(:stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
@@ -13,95 +13,21 @@ RSpec.describe SolidusStripe::Webhook::ChargeSubscriber do
         payment_method: payment_method,
         response_code: stripe_payment_intent.id,
         state: "completed")
-      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123", amount_refunded: 500,
-        currency: 'usd')
+      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123")
+      allow(Stripe::Refund).to receive(:list).with(payment_intent: stripe_payment_intent.id).and_return(
+        Stripe::ListObject.construct_from(
+          data: [{ id: "re_123", amount: 1000, currency: "usd", metadata: {} }]
+        )
+      )
       event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
         payment_method: payment_method,
         object: stripe_charge,
         type: "charge.refunded"
       ).solidus_stripe_object
 
-      described_class.new.refund_payment(event)
+      described_class.new.sync_refunds(event)
 
-      refund = payment.reload.refunds.last
-      expect(refund).not_to be(nil)
-      expect(refund.amount).to eq(5)
-      expect(refund.transaction_id).to eq("pi_123")
-      expect(refund.reason.name).to eq(SolidusStripe::Seeds::DEFAULT_STRIPE_REFUND_REASON_NAME)
-    end
-
-    it "deduces previously refunded amount" do
-      SolidusStripe::Seeds.refund_reasons
-      payment_method = create(:stripe_payment_method)
-      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
-      payment = create(:payment,
-        amount: 10,
-        payment_method: payment_method,
-        response_code: stripe_payment_intent.id,
-        state: "completed")
-      create(:refund, payment: payment, amount: 5)
-      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123", amount_refunded: 700,
-        currency: 'usd')
-      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
-        payment_method: payment_method,
-        object: stripe_charge,
-        type: "charge.refunded"
-      ).solidus_stripe_object
-
-      described_class.new.refund_payment(event)
-
-      refund = payment.reload.refunds.last
-      expect(refund.amount).to eq(2)
-    end
-
-    it "adds a log entry to the payment" do
-      SolidusStripe::Seeds.refund_reasons
-      payment_method = create(:stripe_payment_method)
-      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
-      payment = create(:payment,
-        amount: 10,
-        payment_method: payment_method,
-        response_code: stripe_payment_intent.id,
-        state: "completed")
-      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123", amount_refunded: 500,
-        currency: 'usd')
-      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
-        payment_method: payment_method,
-        object: stripe_charge,
-        type: "charge.refunded"
-      ).solidus_stripe_object
-
-      described_class.new.refund_payment(event)
-
-      details = payment.log_entries.last.parsed_details
-      expect(details.success?).to be(true)
-      expect(
-        details.message
-      ).to eq "Payment was refunded after charge.refunded webhook ($5.00)"
-    end
-
-    it "does nothing if the payment is already totally refunded" do
-      SolidusStripe::Seeds.refund_reasons
-      payment_method = create(:stripe_payment_method)
-      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
-      payment = create(:payment,
-        amount: 10,
-        payment_method: payment_method,
-        response_code: stripe_payment_intent.id,
-        state: "completed")
-      create(:refund, payment: payment, amount: 10)
-      stripe_charge = Stripe::Charge.construct_from(id: "ch_123", payment_intent: "pi_123", amount_refunded: 1000,
-        currency: 'usd')
-      event = SolidusStripe::Webhook::EventWithContextFactory.from_object(
-        payment_method: payment_method,
-        object: stripe_charge,
-        type: "charge.refunded"
-      ).solidus_stripe_object
-
-      described_class.new.refund_payment(event)
-
-      expect(payment.reload.refunds.count).to be(1)
-      expect(payment.log_entries.count).to be(0)
+      expect(payment.refunds.count).to be(1)
     end
   end
 end


### PR DESCRIPTION
## Summary

Stripe doesn't guarantee that a webhook event will be delivered only once, so we need to be prepared to handle duplicated incoming refund events. Just creating a Solidus copy whenever we receive a refund event is not enough.

On top of that, Stripe won't identify the refund that triggered the event. Both the `charge.refunded` and `payment_intent.succeeded` (for partial captures, which generates a refund for the remaining amount under the hood) webhooks only give us information to retrieve the list of all refunds associated with a charge or payment intent.

Because of this, we are now syncing all the refunds associated with a payment intent at every webhook event. We keep track of the refunds already present on Solidus by leveraging the `transaction_id` field on `Spree::Refund`, copying the Stripe refund id as value.

On top of that, we need to account for refunds created from Solidus admin panel, which calls the Stripe API. In this case, we need to avoid syncing the refund back to Solidus on the subsequent webhook. We're marking those refunds with a metadata field on Stripe, so we can exclude them from the sync.

Closes #262

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
