### PR TITLE
Protect against concurrent duplicated webhooks

### DIFF
--- a/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
     it "does nothing if the payment is already voided" do
       payment_method = create(:stripe_payment_method)
-      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
+      stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
       payment = create(:payment,
         payment_method: payment_method,
         response_code: stripe_payment_intent.id,


### PR DESCRIPTION
## Summary

By acquiring an update lock on the payment, we can ensure that only one concurrent excecution of the webhook handler will manipulate it. That will avoid duplicated log entries and obscure exceptions.

Closes #188

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
