### PR TITLE
Support partial capture for previously authorized payments

### DIFF
--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -79,7 +79,7 @@ module SolidusStripe
       check_given_amount_matches_payment_intent(amount_in_cents, options)
       check_payment_intent_id(payment_intent_id)
 
-      payment_intent = capture_stripe_payment_intent(payment_intent_id)
+      payment_intent = capture_stripe_payment_intent(payment_intent_id, amount_in_cents)
       build_payment_log(
         success: true,
         message: "PaymentIntent was confirmed successfully",
@@ -203,8 +203,8 @@ module SolidusStripe
       request { Stripe::PaymentIntent.confirm(stripe_payment_intent_id) }
     end
 
-    def capture_stripe_payment_intent(stripe_payment_intent_id)
-      request { Stripe::PaymentIntent.capture(stripe_payment_intent_id) }
+    def capture_stripe_payment_intent(stripe_payment_intent_id, amount)
+      request { Stripe::PaymentIntent.capture(stripe_payment_intent_id, amount: amount) }
     end
 
     def check_given_amount_matches_payment_intent(amount_in_cents, options)

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       result = gateway.capture(123_45, "pi_123", originator: payment)
 
-      expect(Stripe::PaymentIntent).to have_received(:capture).with('pi_123')
+      expect(Stripe::PaymentIntent).to have_received(:capture).with('pi_123', { amount: 12_345 })
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 

--- a/spec/support/solidus_stripe/backend_test_helper.rb
+++ b/spec/support/solidus_stripe/backend_test_helper.rb
@@ -132,6 +132,18 @@ module SolidusStripe::BackendTestHelper
     end
   end
 
+  def capture_partial_payment_amount(payment, amount)
+    within_row(1) do
+      click_icon(:edit)
+      fill_in('amount', with: amount)
+      click_icon(:ok)
+      expect(page).to have_selector('td.amount span', text: amount.to_money.format)
+      expect(payment.reload.amount).to eq(amount)
+    end
+
+    capture_payment
+  end
+
   def void_payment
     click_icon(:void)
   end
@@ -205,6 +217,6 @@ module SolidusStripe::BackendTestHelper
 
   def expects_payment_to_have_correct_capture_amount_on_stripe(payment, amount)
     stripe_payment_intent = fetch_stripe_payment_intent(payment)
-    expect(stripe_payment_intent.amount_received).to eq(amount * 100)
+    expect(stripe_payment_intent.amount_received).to eq(amount.to_money.fractional)
   end
 end

--- a/spec/system/backend/solidus_stripe/orders/payments_spec.rb
+++ b/spec/system/backend/solidus_stripe/orders/payments_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'SolidusStripe Orders Payments', :js do
       expects_page_to_display_log_messages(["PaymentIntent was confirmed and captured successfully"])
     end
 
-    it 'captures an authorized payment successfully' do
+    it 'successfully captures an authorized payment' do
       payment = create_authorized_payment
       visit_payments_page
 
@@ -30,6 +30,18 @@ RSpec.describe 'SolidusStripe Orders Payments', :js do
 
       expects_page_to_display_successfully_captured_payment(payment)
       expects_payment_to_have_correct_capture_amount_on_stripe(payment, payment.amount)
+    end
+
+    it 'successfully captures a partial amount of an authorized payment' do
+      payment = create_authorized_payment
+      partial_capture_amount = payment.amount - 10
+
+      visit_payments_page
+
+      capture_partial_payment_amount(payment, partial_capture_amount)
+
+      expects_page_to_display_successfully_captured_payment(payment)
+      expects_payment_to_have_correct_capture_amount_on_stripe(payment, partial_capture_amount)
     end
 
     it 'voids a payment from an order' do


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->


This PR enables the capture of a specific portion of a previously authorized payment.
By specifying the amount in the capture gateway action, admins can also perform partial captures via the admin interface.

Fixes #186

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
