### PR TITLE
Improve consistency in naming

### DIFF
--- a/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
@@ -17,11 +17,11 @@ module SolidusStripe
       # @see SolidusStripe::RefundsSynchronizer
       def sync_refunds(event)
         payment_method = event.payment_method
-        payment_intent_id = event.data.object.payment_intent
+        stripe_payment_intent_id = event.data.object.payment_intent
 
         RefundsSynchronizer
           .new(payment_method)
-          .call(payment_intent_id)
+          .call(stripe_payment_intent_id)
       end
     end
   end

--- a/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/charge_subscriber.rb
@@ -16,7 +16,7 @@ module SolidusStripe
       # @param event [SolidusStripe::Webhook::Event]
       # @see SolidusStripe::RefundsSynchronizer
       def sync_refunds(event)
-        payment_method = event.spree_payment_method
+        payment_method = event.payment_method
         payment_intent_id = event.data.object.payment_intent
 
         RefundsSynchronizer

--- a/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
@@ -102,7 +102,7 @@ module SolidusStripe
         }
         return if stripe_amount == stripe_amount_received
 
-        payment_method = event.spree_payment_method
+        payment_method = event.payment_method
         RefundsSynchronizer
           .new(payment_method)
           .call(payment_intent_id)

--- a/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
+++ b/app/subscribers/solidus_stripe/webhook/payment_intent_subscriber.rb
@@ -79,8 +79,8 @@ module SolidusStripe
       private
 
       def extract_payment_from_event(event)
-        payment_intent_id = event.data.object.id
-        Spree::Payment.find_by!(response_code: payment_intent_id)
+        stripe_payment_intent_id = event.data.object.id
+        Spree::Payment.find_by!(response_code: stripe_payment_intent_id)
       end
 
       def complete_payment(payment)
@@ -95,7 +95,7 @@ module SolidusStripe
 
       def sync_refunds(event)
         event.data.object.to_hash => {
-          id: payment_intent_id,
+          id: stripe_payment_intent_id,
           amount: stripe_amount,
           amount_received: stripe_amount_received,
           currency:
@@ -105,7 +105,7 @@ module SolidusStripe
         payment_method = event.payment_method
         RefundsSynchronizer
           .new(payment_method)
-          .call(payment_intent_id)
+          .call(stripe_payment_intent_id)
       end
     end
   end

--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -64,18 +64,18 @@ module SolidusStripe
       end
     end
 
-    def stripe_refund_needs_sync?(refund)
-      originated_outside_solidus = refund.metadata[SKIP_SYNC_METADATA_KEY] != SKIP_SYNC_METADATA_VALUE
-      not_already_synced = Spree::Refund.find_by(transaction_id: refund.id).nil?
+    def stripe_refund_needs_sync?(stripe_refund)
+      originated_outside_solidus = stripe_refund.metadata[SKIP_SYNC_METADATA_KEY] != SKIP_SYNC_METADATA_VALUE
+      not_already_synced = Spree::Refund.find_by(transaction_id: stripe_refund.id).nil?
 
       originated_outside_solidus && not_already_synced
     end
 
-    def create_refund(payment, refund)
+    def create_refund(payment, stripe_refund)
       Spree::Refund.create!(
         payment: payment,
-        amount: refund_decimal_amount(refund),
-        transaction_id: refund.id,
+        amount: refund_decimal_amount(stripe_refund),
+        transaction_id: stripe_refund.id,
         reason: SolidusStripe::PaymentMethod.refund_reason
       ).tap(&method(:log_refund).curry[payment])
     end
@@ -88,9 +88,9 @@ module SolidusStripe
       )
     end
 
-    def refund_decimal_amount(refund)
-      to_solidus_amount(refund.amount, refund.currency)
-        .then { |amount| solidus_subunit_to_decimal(amount, refund.currency) }
+    def refund_decimal_amount(stripe_refund)
+      to_solidus_amount(stripe_refund.amount, stripe_refund.currency)
+        .then { |amount| solidus_subunit_to_decimal(amount, stripe_refund.currency) }
     end
   end
 end

--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -45,11 +45,11 @@ module SolidusStripe
       @payment_method = payment_method
     end
 
-    # @param payment_intent_id [String]
-    def call(payment_intent_id)
-      payment = Spree::Payment.find_by!(response_code: payment_intent_id)
+    # @param stripe_payment_intent_id [String]
+    def call(stripe_payment_intent_id)
+      payment = Spree::Payment.find_by!(response_code: stripe_payment_intent_id)
 
-      stripe_refunds(payment_intent_id)
+      stripe_refunds(stripe_payment_intent_id)
         .select(&method(:stripe_refund_needs_sync?))
         .map(
           &method(:create_refund).curry[payment]
@@ -58,9 +58,9 @@ module SolidusStripe
 
     private
 
-    def stripe_refunds(payment_intent_id)
+    def stripe_refunds(stripe_payment_intent_id)
       @payment_method.gateway.request do
-        Stripe::Refund.list(payment_intent: payment_intent_id).data
+        Stripe::Refund.list(payment_intent: stripe_payment_intent_id).data
       end
     end
 

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :stripe_payment_method, class: 'SolidusStripe::PaymentMethod' do
+  factory :solidus_stripe_payment_method, class: 'SolidusStripe::PaymentMethod' do
     type { "SolidusStripe::PaymentMethod" }
     name { "Stripe Payment Method" }
     preferences {
@@ -16,13 +16,13 @@ FactoryBot.define do
     }
   end
 
-  factory :stripe_payment_source, class: 'SolidusStripe::PaymentSource' do
-    association :payment_method, factory: :stripe_payment_method
+  factory :solidus_stripe_payment_source, class: 'SolidusStripe::PaymentSource' do
+    association :payment_method, factory: :solidus_stripe_payment_method
     stripe_payment_method_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
 
-  factory :stripe_payment, parent: :payment do
-    association :payment_method, factory: :stripe_payment_method
+  factory :solidus_stripe_payment, parent: :payment do
+    association :payment_method, factory: :solidus_stripe_payment_method
     amount { order.outstanding_balance }
     response_code { "pi_#{SecureRandom.uuid.delete('-')}" }
     state { 'checkout' }
@@ -33,7 +33,7 @@ FactoryBot.define do
 
     source {
       create(
-        :stripe_payment_source,
+        :solidus_stripe_payment_source,
         payment_method: payment_method,
         stripe_payment_method_id: stripe_payment_method_id
       )
@@ -44,7 +44,7 @@ FactoryBot.define do
 
       after(:create) do |payment, _evaluator|
         create(
-          :stripe_payment_log_entry,
+          :solidus_stripe_payment_log_entry,
           :authorize,
           source: payment
         )
@@ -56,7 +56,7 @@ FactoryBot.define do
 
       after(:create) do |payment, _evaluator|
         create(
-          :stripe_payment_log_entry,
+          :solidus_stripe_payment_log_entry,
           :autocapture,
           source: payment
         )
@@ -64,19 +64,19 @@ FactoryBot.define do
     end
   end
 
-  factory :stripe_payment_intent, class: 'SolidusStripe::PaymentIntent' do
+  factory :solidus_stripe_payment_intent, class: 'SolidusStripe::PaymentIntent' do
     association :order
-    association :payment_method, factory: :stripe_payment_method
+    association :payment_method, factory: :solidus_stripe_payment_method
     stripe_intent_id { "pm_#{SecureRandom.uuid.delete('-')}" }
   end
 
-  factory :stripe_slug_entry, class: 'SolidusStripe::SlugEntry' do
-    association :payment_method, factory: :stripe_payment_method
+  factory :solidus_stripe_slug_entry, class: 'SolidusStripe::SlugEntry' do
+    association :payment_method, factory: :solidus_stripe_payment_method
     slug { SecureRandom.hex(16) }
   end
 
-  factory :stripe_customer, class: 'SolidusStripe::Customer' do
-    association :payment_method, factory: :stripe_payment_method
+  factory :solidus_stripe_customer, class: 'SolidusStripe::Customer' do
+    association :payment_method, factory: :solidus_stripe_payment_method
     association :source, factory: :user
     stripe_id { "cus_#{SecureRandom.uuid.delete('-')}" }
 
@@ -85,7 +85,7 @@ FactoryBot.define do
     end
   end
 
-  factory :stripe_payment_log_entry, class: 'Spree::LogEntry' do
+  factory :solidus_stripe_payment_log_entry, class: 'Spree::LogEntry' do
     transient do
       success { true }
       message { nil }
@@ -137,7 +137,7 @@ FactoryBot.define do
   factory :order_with_stripe_payment, parent: :order do
     transient do
       amount { 10 }
-      payment_method { build(:stripe_payment_method) }
+      payment_method { build(:solidus_stripe_payment_method) }
       stripe_payment_method_id { "pm_#{SecureRandom.uuid.delete('-')}" }
     end
 
@@ -145,7 +145,7 @@ FactoryBot.define do
 
     after(:create) do |order, evaluator|
       build(
-        :stripe_payment,
+        :solidus_stripe_payment,
         amount: evaluator.amount,
         order: order,
         payment_method: evaluator.payment_method,

--- a/lib/solidus_stripe/testing_support/factories.rb
+++ b/lib/solidus_stripe/testing_support/factories.rb
@@ -134,7 +134,7 @@ FactoryBot.define do
     }
   end
 
-  factory :order_with_stripe_payment, parent: :order do
+  factory :solidus_stripe_order, parent: :order do
     transient do
       amount { 10 }
       payment_method { build(:solidus_stripe_payment_method) }

--- a/lib/solidus_stripe/webhook/event.rb
+++ b/lib/solidus_stripe/webhook/event.rb
@@ -31,7 +31,7 @@ module SolidusStripe
             payment_method.preferred_webhook_endpoint_signing_secret,
             tolerance: tolerance
           )
-          new(stripe_event: stripe_event, spree_payment_method: payment_method)
+          new(stripe_event: stripe_event, payment_method: payment_method)
         rescue ActiveRecord::RecordNotFound, Stripe::SignatureVerificationError, JSON::ParserError
           nil
         end
@@ -53,12 +53,12 @@ module SolidusStripe
       attr_reader :omnes_event_name
 
       # @attr_reader [SolidusStripe::PaymentMethod]
-      attr_reader :spree_payment_method
+      attr_reader :payment_method
 
       # @api private
-      def initialize(stripe_event:, spree_payment_method:)
+      def initialize(stripe_event:, payment_method:)
         @stripe_event = stripe_event
-        @spree_payment_method = spree_payment_method
+        @payment_method = payment_method
         @omnes_event_name = :"#{PREFIX}#{stripe_event.type}"
       end
 
@@ -72,7 +72,7 @@ module SolidusStripe
       def payload
         {
           "stripe_event" => @stripe_event.as_json,
-          "spree_payment_method_id" => @spree_payment_method.id
+          "payment_method_id" => @payment_method.id
         }
       end
 

--- a/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
+++ b/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
@@ -5,7 +5,7 @@ require "solidus_stripe/refunds_synchronizer"
 require "solidus_stripe/seeds"
 
 RSpec.describe SolidusStripe::RefundsSynchronizer do
-  def mock_refund_list(payment_intent_id, refunds)
+  def mock_stripe_refund_list(payment_intent_id, refunds)
     allow(Stripe::Refund).to receive(:list).with(payment_intent: payment_intent_id).and_return(
       Stripe::ListObject.construct_from(
         data: refunds
@@ -20,7 +20,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -38,7 +38,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -57,7 +57,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -76,7 +76,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -94,7 +94,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
     it "skips the creation of Solidus refunds with transaction_id matching some stripe refund id" do
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -112,7 +112,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
     it "skips the creation of Solidus refunds when specified in their metadata" do
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -132,7 +132,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 500,
@@ -156,7 +156,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 500,
@@ -181,7 +181,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -199,7 +199,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -219,7 +219,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       SolidusStripe::Seeds.refund_reasons
       payment_intent_id = "pi_123"
       payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_refund_list(payment_intent_id, [
+      mock_stripe_refund_list(payment_intent_id, [
         {
           id: "re_123",
           amount: 500,

--- a/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
+++ b/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
@@ -5,8 +5,8 @@ require "solidus_stripe/refunds_synchronizer"
 require "solidus_stripe/seeds"
 
 RSpec.describe SolidusStripe::RefundsSynchronizer do
-  def mock_stripe_refund_list(payment_intent_id, refunds)
-    allow(Stripe::Refund).to receive(:list).with(payment_intent: payment_intent_id).and_return(
+  def mock_stripe_refund_list(stripe_payment_intent_id, refunds)
+    allow(Stripe::Refund).to receive(:list).with(payment_intent: stripe_payment_intent_id).and_return(
       Stripe::ListObject.construct_from(
         data: refunds
       )
@@ -18,9 +18,9 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
 
     it "creates missing refunds on Solidus" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -29,16 +29,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.refunds.count).to eq(1)
     end
 
     it "uses the stripe refund id as created Solidus refund transaction_id field" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -47,7 +47,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       refund = payment.refunds.first
       expect(refund.transaction_id).to eq("re_123")
@@ -55,9 +55,9 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
 
     it "uses the stripe amount as created Solidus refund amount" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -66,7 +66,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       refund = payment.refunds.first
       expect(refund.amount).to eq(10)
@@ -74,9 +74,9 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
 
     it "uses the configured reason for created Solidus refunds" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -85,16 +85,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       refund = payment.refunds.first
       expect(refund.reason).to eq(SolidusStripe::PaymentMethod.refund_reason)
     end
 
     it "skips the creation of Solidus refunds with transaction_id matching some stripe refund id" do
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -104,15 +104,15 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       ])
       create(:refund, amount: 10, payment: payment, transaction_id: "re_123")
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.refunds.count).to be(1)
     end
 
     it "skips the creation of Solidus refunds when specified in their metadata" do
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -123,16 +123,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.refunds.count).to be(0)
     end
 
     it "creates multiple Solidus refunds if needed" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 500,
@@ -147,16 +147,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.refunds.count).to be(2)
     end
 
     it "creates only the missing Solidus refunds when there're multiple Stripe refunds" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 500,
@@ -172,16 +172,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
       ])
       create(:refund, amount: 5, payment: payment, transaction_id: "re_123")
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.refunds.pluck(:transaction_id)).to contain_exactly("re_123", "re_456")
     end
 
     it "adds a log entry for created Solidus refund" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -190,16 +190,16 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(payment.log_entries.count).to eq(1)
     end
 
     it "sets created log entry as successful" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 1000,
@@ -208,7 +208,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(
         payment.log_entries.first.parsed_details.success?
@@ -217,9 +217,9 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
 
     it "uses a meaningful message with the refunded amount in created log entry" do
       SolidusStripe::Seeds.refund_reasons
-      payment_intent_id = "pi_123"
-      payment = create(:payment, response_code: payment_intent_id, amount: 10, payment_method: payment_method)
-      mock_stripe_refund_list(payment_intent_id, [
+      stripe_payment_intent_id = "pi_123"
+      payment = create(:payment, response_code: stripe_payment_intent_id, amount: 10, payment_method: payment_method)
+      mock_stripe_refund_list(stripe_payment_intent_id, [
         {
           id: "re_123",
           amount: 500,
@@ -228,7 +228,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
         }
       ])
 
-      described_class.new(payment_method).call(payment_intent_id)
+      described_class.new(payment_method).call(stripe_payment_intent_id)
 
       expect(
         payment.log_entries.first.parsed_details.message

--- a/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
+++ b/spec/lib/solidus_stripe/refunds_synchronizer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SolidusStripe::RefundsSynchronizer do
   end
 
   describe "#call" do
-    let(:payment_method) { create(:stripe_payment_method) }
+    let(:payment_method) { create(:solidus_stripe_payment_method) }
 
     it "creates missing refunds on Solidus" do
       SolidusStripe::Seeds.refund_reasons

--- a/spec/lib/solidus_stripe/webhook/event_spec.rb
+++ b/spec/lib/solidus_stripe/webhook/event_spec.rb
@@ -93,19 +93,19 @@ RSpec.describe SolidusStripe::Webhook::Event do
     end
 
     it "sets the payment method" do
-      event = described_class.new(stripe_event: context.stripe_object, spree_payment_method: context.payment_method)
+      event = described_class.new(stripe_event: context.stripe_object, payment_method: context.payment_method)
 
-      expect(event.spree_payment_method).to be(context.payment_method)
+      expect(event.payment_method).to be(context.payment_method)
     end
 
     it "sets the omnes_event_name from the event type field" do
-      event = described_class.new(stripe_event: context.stripe_object, spree_payment_method: context.payment_method)
+      event = described_class.new(stripe_event: context.stripe_object, payment_method: context.payment_method)
 
       expect(event.omnes_event_name).to be(:"stripe.charge.succeeded")
     end
 
     it "delegates all other methods to the stripe event" do
-      event = described_class.new(stripe_event: context.stripe_object, spree_payment_method: context.payment_method)
+      event = described_class.new(stripe_event: context.stripe_object, payment_method: context.payment_method)
 
       expect(event.type).to eq("charge.succeeded")
     end
@@ -120,15 +120,15 @@ RSpec.describe SolidusStripe::Webhook::Event do
     end
 
     it "includes stripe event Hash representation" do
-      event = described_class.new(stripe_event: context.stripe_object, spree_payment_method: context.payment_method)
+      event = described_class.new(stripe_event: context.stripe_object, payment_method: context.payment_method)
 
       expect(event.payload["stripe_event"]).to eq(context.stripe_object.as_json)
     end
 
     it "includes spree payment method id" do
-      event = described_class.new(stripe_event: context.stripe_object, spree_payment_method: context.payment_method)
+      event = described_class.new(stripe_event: context.stripe_object, payment_method: context.payment_method)
 
-      expect(event.payload["spree_payment_method_id"]).to be(context.payment_method.id)
+      expect(event.payload["payment_method_id"]).to be(context.payment_method.id)
     end
   end
 end

--- a/spec/lib/solidus_stripe/webhook/event_spec.rb
+++ b/spec/lib/solidus_stripe/webhook/event_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SolidusStripe::Webhook::Event do
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.from_data(
         data: SolidusStripe::Webhook::DataFixtures.charge_succeeded,
-        payment_method: create(:stripe_payment_method)
+        payment_method: create(:solidus_stripe_payment_method)
       )
     end
 
@@ -88,7 +88,7 @@ RSpec.describe SolidusStripe::Webhook::Event do
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.new(
         data: SolidusStripe::Webhook::DataFixtures.charge_succeeded,
-        payment_method: create(:stripe_payment_method)
+        payment_method: create(:solidus_stripe_payment_method)
       )
     end
 
@@ -115,7 +115,7 @@ RSpec.describe SolidusStripe::Webhook::Event do
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.new(
         data: SolidusStripe::Webhook::DataFixtures.charge_succeeded,
-        payment_method: create(:stripe_payment_method)
+        payment_method: create(:solidus_stripe_payment_method)
       )
     end
 

--- a/spec/models/solidus_stripe/customer_spec.rb
+++ b/spec/models/solidus_stripe/customer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SolidusStripe::Customer, type: :model do
       it 'returns the customer_id' do
         user = create(:user)
         order = create(:order, user: user)
-        customer = create(:stripe_customer, stripe_id: 'cus_123', source: user)
+        customer = create(:solidus_stripe_customer, stripe_id: 'cus_123', source: user)
 
         expect(customer.source).to be_a(Spree::User)
         expect(
@@ -21,7 +21,7 @@ RSpec.describe SolidusStripe::Customer, type: :model do
       it 'creates the customer from a user' do
         user = create(:user, email: 'registered@example.com')
         order = create(:order, user: user)
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
 
         stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
         allow(Stripe::Customer).to receive(:create).with(email: 'registered@example.com').and_return(stripe_customer)
@@ -32,7 +32,7 @@ RSpec.describe SolidusStripe::Customer, type: :model do
       end
 
       it 'creates the customer from a guest order' do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         order = create(:order, user: nil, email: 'guest@example.com')
 
         stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment,
+      order = create(:solidus_stripe_order,
         amount: 123.45,
         payment_method: payment_method,
         stripe_payment_method_id: stripe_payment_method.id)
@@ -50,7 +50,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment,
+      order = create(:solidus_stripe_order,
         amount: 123.45,
         payment_method: payment_method,
         stripe_payment_method_id: stripe_payment_method.id)
@@ -73,7 +73,7 @@ RSpec.describe SolidusStripe::Gateway do
     it "raises if the given amount doesn't match the order total" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
 
       expect { gateway.authorize(10, :source, originator: order.payments.first ) }.to raise_error(
         /custom amount is not supported/
@@ -99,7 +99,7 @@ RSpec.describe SolidusStripe::Gateway do
     it "raises if the given amount doesn't match the order total" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
 
       expect { gateway.capture(10, :payment_intent_id, originator: order.payments.first ) }.to raise_error(
         /custom amount is not supported/
@@ -109,7 +109,7 @@ RSpec.describe SolidusStripe::Gateway do
     it "raises if no payment_intent_id is given" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
 
       expect { gateway.capture(123_45, nil, originator: order.payments.first ) }.to raise_error(
         ArgumentError,
@@ -120,7 +120,7 @@ RSpec.describe SolidusStripe::Gateway do
     it "raises if payment_intent_id is not valid" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
 
       expect { gateway.capture(123_45, "invalid", originator: order.payments.first ) }.to raise_error(
         ArgumentError,
@@ -170,7 +170,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment,
+      order = create(:solidus_stripe_order,
         amount: 123.45,
         payment_method: payment_method,
         stripe_payment_method_id: stripe_payment_method.id)
@@ -209,7 +209,7 @@ RSpec.describe SolidusStripe::Gateway do
 
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment,
+      order = create(:solidus_stripe_order,
         amount: 123.45,
         payment_method: payment_method,
         stripe_payment_method_id: stripe_payment_method.id)
@@ -232,7 +232,7 @@ RSpec.describe SolidusStripe::Gateway do
     it "raises if the given amount doesn't match the order total" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
-      order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
+      order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
 
       expect { gateway.purchase(10, :source, originator: order.payments.first ) }.to raise_error(
         /custom amount is not supported/

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -113,11 +113,11 @@ RSpec.describe SolidusStripe::Gateway do
 
       expect { gateway.capture(123_45, nil, originator: order.payments.first ) }.to raise_error(
         ArgumentError,
-        /missing payment_intent_id/
+        /missing stripe_payment_intent_id/
       )
     end
 
-    it "raises if payment_intent_id is not valid" do
+    it "raises if stripe_payment_intent_id is not valid" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:solidus_stripe_order, amount: 123.45, payment_method: payment_method)
@@ -141,17 +141,17 @@ RSpec.describe SolidusStripe::Gateway do
       expect(result.params).to eq("data" => '{"id":"pi_123"}')
     end
 
-    it "raises if no payment_intent_id is given" do
+    it "raises if no stripe_payment_intent_id is given" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.void(nil) }.to raise_error(
         ArgumentError,
-        /missing payment_intent_id/
+        /missing stripe_payment_intent_id/
       )
     end
 
-    it "raises if payment_intent_id is not valid" do
+    it "raises if stripe_payment_intent_id is not valid" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
@@ -260,17 +260,17 @@ RSpec.describe SolidusStripe::Gateway do
       expect(result.params).to eq("data" => '{"id":"re_123"}')
     end
 
-    it "raises if no payment_intent_id is given" do
+    it "raises if no stripe_payment_intent_id is given" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.credit(:amount, nil) }.to raise_error(
         ArgumentError,
-        /missing payment_intent_id/
+        /missing stripe_payment_intent_id/
       )
     end
 
-    it "raises if payment_intent_id is not valid" do
+    it "raises if stripe_payment_intent_id is not valid" do
       payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SolidusStripe::Gateway do
       stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
 
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment,
         amount: 123.45,
@@ -48,7 +48,7 @@ RSpec.describe SolidusStripe::Gateway do
       stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
 
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment,
         amount: 123.45,
@@ -71,7 +71,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if the given amount doesn't match the order total" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
 
@@ -85,7 +85,7 @@ RSpec.describe SolidusStripe::Gateway do
     it 'captures a pre-authorized Stripe payment' do
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
 
-      gateway = build(:stripe_payment_method).gateway
+      gateway = build(:solidus_stripe_payment_method).gateway
       payment = build(:payment, response_code: "pi_123", amount: 123.45)
 
       allow(Stripe::PaymentIntent).to receive(:capture).and_return(stripe_payment_intent)
@@ -97,7 +97,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if the given amount doesn't match the order total" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
 
@@ -107,7 +107,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if no payment_intent_id is given" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
 
@@ -118,7 +118,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if payment_intent_id is not valid" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
 
@@ -131,7 +131,7 @@ RSpec.describe SolidusStripe::Gateway do
 
   describe '#void' do
     it 'voids a payment that hasn not been captured yet' do
-      gateway = build(:stripe_payment_method).gateway
+      gateway = build(:solidus_stripe_payment_method).gateway
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       allow(Stripe::PaymentIntent).to receive(:cancel).and_return(stripe_payment_intent)
 
@@ -142,7 +142,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if no payment_intent_id is given" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.void(nil) }.to raise_error(
@@ -152,7 +152,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if payment_intent_id is not valid" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.void("invalid") }.to raise_error(
@@ -168,7 +168,7 @@ RSpec.describe SolidusStripe::Gateway do
       stripe_customer = Stripe::Customer.construct_from(id: 'cus_123')
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
 
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment,
         amount: 123.45,
@@ -207,7 +207,7 @@ RSpec.describe SolidusStripe::Gateway do
       stripe_payment_method = Stripe::PaymentMethod.construct_from(id: "pm_123")
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
 
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment,
         amount: 123.45,
@@ -230,7 +230,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if the given amount doesn't match the order total" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
       order = create(:order_with_stripe_payment, amount: 123.45, payment_method: payment_method)
 
@@ -242,7 +242,7 @@ RSpec.describe SolidusStripe::Gateway do
 
   describe '#credit' do
     it 'refunds when provided an originator payment' do
-      gateway = build(:stripe_payment_method).gateway
+      gateway = build(:solidus_stripe_payment_method).gateway
       payment = instance_double(Spree::Payment, response_code: 'pi_123', currency: "USD")
       refund = Stripe::Refund.construct_from(id: "re_123")
       allow(Stripe::Refund).to receive(:create).and_return(refund)
@@ -261,7 +261,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if no payment_intent_id is given" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.credit(:amount, nil) }.to raise_error(
@@ -271,7 +271,7 @@ RSpec.describe SolidusStripe::Gateway do
     end
 
     it "raises if payment_intent_id is not valid" do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
       gateway = payment_method.gateway
 
       expect { gateway.credit(:amount, "invalid") }.to raise_error(

--- a/spec/models/solidus_stripe/gateway_spec.rb
+++ b/spec/models/solidus_stripe/gateway_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe SolidusStripe::Gateway do
     it 'refunds when provided an originator payment' do
       gateway = build(:solidus_stripe_payment_method).gateway
       payment = instance_double(Spree::Payment, response_code: 'pi_123', currency: "USD")
-      refund = Stripe::Refund.construct_from(id: "re_123")
-      allow(Stripe::Refund).to receive(:create).and_return(refund)
+      stripe_refund = Stripe::Refund.construct_from(id: "re_123")
+      allow(Stripe::Refund).to receive(:create).and_return(stripe_refund)
 
       result = gateway.credit(123_45, 'pi_123', currency: 'USD', originator: instance_double(
         Spree::Refund,

--- a/spec/models/solidus_stripe/payment_intent_spec.rb
+++ b/spec/models/solidus_stripe/payment_intent_spec.rb
@@ -5,7 +5,7 @@ require 'solidus_stripe_spec_helper'
 RSpec.describe SolidusStripe::PaymentIntent do
   describe "#reload" do
     it "reloads the stripe intent" do
-      intent = create(:stripe_payment_intent)
+      intent = create(:solidus_stripe_payment_intent)
       allow(Stripe::PaymentIntent).to receive(:retrieve) do
         Stripe::PaymentIntent.construct_from(id: intent.stripe_intent_id)
       end

--- a/spec/models/solidus_stripe/payment_method_spec.rb
+++ b/spec/models/solidus_stripe/payment_method_spec.rb
@@ -4,13 +4,13 @@ require 'solidus_stripe_spec_helper'
 
 RSpec.describe SolidusStripe::PaymentMethod do
   it 'has a working factory' do
-    expect(create(:stripe_payment_method)).to be_valid
+    expect(create(:solidus_stripe_payment_method)).to be_valid
   end
 
   describe 'Callbacks' do
     describe 'after_create' do
       it 'creates a webhook endpoint' do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
 
         expect(payment_method.slug_entry).to be_present
       end
@@ -28,7 +28,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
 
     context 'when the order has a payment intent' do
       it 'fetches the payment intent id' do
-        intent = create(:stripe_payment_intent, stripe_intent_id: 'pi_123')
+        intent = create(:solidus_stripe_payment_intent, stripe_intent_id: 'pi_123')
         payment = build(:payment, response_code: nil, payment_method: intent.payment_method, order: intent.order)
 
         expect(described_class.intent_id_for_payment(payment)).to eq("pi_123")
@@ -43,20 +43,20 @@ RSpec.describe SolidusStripe::PaymentMethod do
   describe '#stripe_dashboard_url' do
     context 'with a payment intent id' do
       it 'generates a dashboard link' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+        payment_method = build(:solidus_stripe_payment_method, preferred_test_mode: false)
 
         expect(payment_method.stripe_dashboard_url('pi_123')).to eq("https://dashboard.stripe.com/payments/pi_123")
       end
 
       it 'supports test mode' do
-        payment_method = build(:stripe_payment_method, preferred_test_mode: true)
+        payment_method = build(:solidus_stripe_payment_method, preferred_test_mode: true)
 
         expect(payment_method.stripe_dashboard_url('pi_123')).to eq("https://dashboard.stripe.com/test/payments/pi_123")
       end
     end
 
     it 'returns nil with anything else' do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
 
       expect(payment_method.stripe_dashboard_url(Object.new)).to eq(nil)
       expect(payment_method.stripe_dashboard_url('')).to eq(nil)
@@ -66,7 +66,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
 
   describe '.with_slug' do
     it 'selects by slug' do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
 
       expect(described_class.with_slug(payment_method.slug)).to eq([payment_method])
       expect(described_class.with_slug('bad-slug')).to eq([])
@@ -75,14 +75,14 @@ RSpec.describe SolidusStripe::PaymentMethod do
 
   describe '.previous_sources' do
     it 'finds no sources associated with the order' do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       order = create(:order, user: nil)
 
       expect(payment_method.previous_sources(order)).to be_empty
     end
 
     it 'finds no sources associated with the user' do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       user = create(:user)
       order = create(:order, user: user)
 
@@ -90,7 +90,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
     end
 
     it 'finds sources associated with the user' do
-      payment_source = create(:stripe_payment_source)
+      payment_source = create(:solidus_stripe_payment_source)
       payment_method = payment_source.payment_method
       user = create(:user)
       order = create(:order, user: user.reload)
@@ -103,7 +103,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
 
   describe '.assign_slug' do
     it 'generates a "test" slug for the first payment method in test mode' do
-      payment_method = build(:stripe_payment_method)
+      payment_method = build(:solidus_stripe_payment_method)
 
       payment_method.save!
 
@@ -111,7 +111,7 @@ RSpec.describe SolidusStripe::PaymentMethod do
     end
 
     it 'generates a "live" slug for the first payment method in live mode' do
-      payment_method = build(:stripe_payment_method, preferred_test_mode: false)
+      payment_method = build(:solidus_stripe_payment_method, preferred_test_mode: false)
 
       payment_method.save!
 
@@ -119,8 +119,8 @@ RSpec.describe SolidusStripe::PaymentMethod do
     end
 
     it 'generates a random hex string' do
-      _existing_payment_method = create(:stripe_payment_method)
-      payment_method = create(:stripe_payment_method)
+      _existing_payment_method = create(:solidus_stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
 
       expect(payment_method.slug).to match(/^[0-9a-f]{32}$/)
     end
@@ -128,10 +128,10 @@ RSpec.describe SolidusStripe::PaymentMethod do
     it 'generates a unique slug' do
       slug = SecureRandom.hex(16)
 
-      create(:stripe_slug_entry, slug: slug)
+      create(:solidus_stripe_slug_entry, slug: slug)
       allow(SecureRandom).to receive(:hex).and_return(slug).and_call_original
 
-      expect(create(:stripe_payment_method).slug).not_to eq(slug)
+      expect(create(:solidus_stripe_payment_method).slug).not_to eq(slug)
     end
   end
 end

--- a/spec/models/solidus_stripe/payment_source_spec.rb
+++ b/spec/models/solidus_stripe/payment_source_spec.rb
@@ -4,20 +4,20 @@ require 'solidus_stripe_spec_helper'
 
 RSpec.describe SolidusStripe::PaymentSource, type: :model do
   it 'has a working factory' do
-    expect(create(:stripe_payment_source)).to be_valid
+    expect(create(:solidus_stripe_payment_source)).to be_valid
   end
 
   describe '#stripe_payment_method' do
     it 'retrieves the Stripe::PaymentMethod object if the stripe_payment_method id is present' do
       stripe_payment_method = Stripe::PaymentMethod.construct_from(id: 'pm_123')
-      source = create(:stripe_payment_source, stripe_payment_method_id: 'pm_123')
+      source = create(:solidus_stripe_payment_source, stripe_payment_method_id: 'pm_123')
       allow(Stripe::PaymentMethod).to receive(:retrieve).with('pm_123').and_return(stripe_payment_method)
 
       expect(source.stripe_payment_method).to eq(stripe_payment_method)
     end
 
     it 'returns nil if the stripe_payment_method id is missing' do
-      source = create(:stripe_payment_source, stripe_payment_method_id: nil)
+      source = create(:solidus_stripe_payment_source, stripe_payment_method_id: nil)
 
       expect(source.stripe_payment_method).to be_nil
     end

--- a/spec/requests/solidus_stripe/intents_controller_spec.rb
+++ b/spec/requests/solidus_stripe/intents_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SolidusStripe::IntentsController, type: :request do
   describe "GET /after_confirmation" do
     context 'when not provided a payment intent' do
       it 'responds with unprocessable entity' do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         order = create(:order_ready_to_complete)
         sign_in order.user
 
@@ -16,7 +16,7 @@ RSpec.describe SolidusStripe::IntentsController, type: :request do
 
     context 'when the order is not at "confirm"' do
       it 'redirects to the current order step' do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         order = create(:order)
         sign_in order.user
 

--- a/spec/requests/solidus_stripe/webhooks_controller/charge/refunded_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/charge/refunded_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_reque
   describe "POST /create charge.refunded" do
     it "synchronizes refunds" do
       SolidusStripe::Seeds.refund_reasons
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         amount: 10,

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/canceled_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/canceled_spec.rb
@@ -3,7 +3,7 @@ require "solidus_stripe_spec_helper"
 RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
   describe "POST /create payment_intent.canceled" do
     it "transitions the associated payment to failed" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
       payment = create(:payment,
         payment_method: payment_method,

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/payment_failed_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/payment_failed_spec.rb
@@ -3,7 +3,7 @@ require "solidus_stripe_spec_helper"
 RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
   describe "POST /create payment_intent.payment_failed" do
     it "transitions the associated payment to failed" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         payment_method: payment_method,

--- a/spec/requests/solidus_stripe/webhooks_controller/payment_intent/succeeded_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller/payment_intent/succeeded_spec.rb
@@ -3,7 +3,7 @@ require "solidus_stripe_spec_helper"
 RSpec.describe SolidusStripe::WebhooksController, type: %i[request webhook_request] do
   describe "POST /create payment_intent.succeeded" do
     it "captures the associated payment" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(
         id: "pi_123",
         amount: 1000,

--- a/spec/requests/solidus_stripe/webhooks_controller_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller_spec.rb
@@ -3,14 +3,14 @@ require "solidus_stripe_spec_helper"
 RSpec.describe SolidusStripe::WebhooksController, type: [:request, :webhook_request] do
   describe "POST /create" do
     let(:payment_method) { create(:solidus_stripe_payment_method) }
-    let(:payment_intent) {
+    let(:stripe_payment_intent) {
       payment_method.gateway.request {
         Stripe::PaymentIntent.create(amount: 100, currency: 'usd')
       }
     }
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.from_object(
-        object: payment_intent,
+        object: stripe_payment_intent,
         type: "payment_intent.created",
         payment_method: payment_method
       )

--- a/spec/requests/solidus_stripe/webhooks_controller_spec.rb
+++ b/spec/requests/solidus_stripe/webhooks_controller_spec.rb
@@ -2,13 +2,17 @@ require "solidus_stripe_spec_helper"
 
 RSpec.describe SolidusStripe::WebhooksController, type: [:request, :webhook_request] do
   describe "POST /create" do
-    let(:stripe) { create(:stripe_payment_method) }
-    let(:payment_intent) { stripe.gateway.request { Stripe::PaymentIntent.create(amount: 100, currency: 'usd') } }
+    let(:payment_method) { create(:solidus_stripe_payment_method) }
+    let(:payment_intent) {
+      payment_method.gateway.request {
+        Stripe::PaymentIntent.create(amount: 100, currency: 'usd')
+      }
+    }
     let(:context) do
       SolidusStripe::Webhook::EventWithContextFactory.from_object(
         object: payment_intent,
         type: "payment_intent.created",
-        payment_method: stripe
+        payment_method: payment_method
       )
     end
 

--- a/spec/subscribers/solidus_stripe/webhook/charge_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/charge_subscriber_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SolidusStripe::Webhook::ChargeSubscriber do
   describe "#sync_refunds" do
     it "synchronizes refunds" do
       SolidusStripe::Seeds.refund_reasons
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         amount: 10,

--- a/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
+++ b/spec/subscribers/solidus_stripe/webhook/payment_intent_subscriber_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
   describe "#capture_payment" do
     context "when a full capture is performed" do
       it "completes a pending payment" do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         stripe_payment_intent = Stripe::PaymentIntent.construct_from(
           id: "pi_123",
           amount: 1000,
@@ -30,7 +30,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
       end
 
       it "adds a log entry to the payment" do
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         stripe_payment_intent = Stripe::PaymentIntent.construct_from(
           id: "pi_123",
           amount: 1000,
@@ -61,7 +61,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     context "when a partial capture is performed" do
       it "completes a pending payment" do
         SolidusStripe::Seeds.refund_reasons
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         stripe_payment_intent = Stripe::PaymentIntent.construct_from(
           id: "pi_123",
           amount: 1000,
@@ -91,7 +91,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
       it "synchronizes refunds" do
         SolidusStripe::Seeds.refund_reasons
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         stripe_payment_intent = Stripe::PaymentIntent.construct_from(
           id: "pi_123",
           amount: 1000,
@@ -121,7 +121,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
       it "adds a log entry for the captured payment" do
         SolidusStripe::Seeds.refund_reasons
-        payment_method = create(:stripe_payment_method)
+        payment_method = create(:solidus_stripe_payment_method)
         stripe_payment_intent = Stripe::PaymentIntent.construct_from(
           id: "pi_123",
           amount: 1000,
@@ -154,7 +154,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     end
 
     it "does nothing if the payment is already completed" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         payment_method: payment_method,
@@ -175,7 +175,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
   describe "#fail_payment" do
     it "fails a pending payment" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         payment_method: payment_method,
@@ -193,7 +193,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     end
 
     it "adds a log entry to the payment" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         payment_method: payment_method,
@@ -215,7 +215,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     end
 
     it "does nothing if the payment is already failed" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123")
       payment = create(:payment,
         payment_method: payment_method,
@@ -236,7 +236,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
 
   describe "#void_payment" do
     it "voids a pending payment" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
       payment = create(:payment,
         payment_method: payment_method,
@@ -254,7 +254,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     end
 
     it "adds a log entry to the payment" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
       payment = create(:payment,
         payment_method: payment_method,
@@ -276,7 +276,7 @@ RSpec.describe SolidusStripe::Webhook::PaymentIntentSubscriber do
     end
 
     it "does nothing if the payment is already voided" do
-      payment_method = create(:stripe_payment_method)
+      payment_method = create(:solidus_stripe_payment_method)
       stripe_payment_intent = Stripe::PaymentIntent.construct_from(id: "pi_123", cancellation_reason: "duplicate")
       payment = create(:payment,
         payment_method: payment_method,

--- a/spec/support/solidus_stripe/backend_test_helper.rb
+++ b/spec/support/solidus_stripe/backend_test_helper.rb
@@ -77,12 +77,12 @@ module SolidusStripe::BackendTestHelper
 
   def create_authorized_payment(opts = {})
     stripe_payment_method = create_stripe_payment_method(opts[:card_number] || '4242424242424242')
-    payment_intent = create_stripe_payment_intent(stripe_payment_method.id)
+    stripe_payment_intent = create_stripe_payment_intent(stripe_payment_method.id)
 
     create(:solidus_stripe_payment,
       :authorized,
       order: order,
-      response_code: payment_intent.id,
+      response_code: stripe_payment_intent.id,
       stripe_payment_method_id: stripe_payment_method.id,
       payment_method: payment_method)
   end

--- a/spec/support/solidus_stripe/backend_test_helper.rb
+++ b/spec/support/solidus_stripe/backend_test_helper.rb
@@ -3,7 +3,7 @@
 module SolidusStripe::BackendTestHelper
   def create_payment_method(setup_future_usage: 'off_session', auto_capture: false)
     @payment_method = create(
-      :stripe_payment_method,
+      :solidus_stripe_payment_method,
       preferred_setup_future_usage: setup_future_usage,
       auto_capture: auto_capture
     )
@@ -79,7 +79,7 @@ module SolidusStripe::BackendTestHelper
     stripe_payment_method = create_stripe_payment_method(opts[:card_number] || '4242424242424242')
     payment_intent = create_stripe_payment_intent(stripe_payment_method.id)
 
-    create(:stripe_payment,
+    create(:solidus_stripe_payment,
       :authorized,
       order: order,
       response_code: payment_intent.id,

--- a/spec/support/solidus_stripe/checkout_test_helper.rb
+++ b/spec/support/solidus_stripe/checkout_test_helper.rb
@@ -25,7 +25,7 @@ module SolidusStripe::CheckoutTestHelper
 
   def create_payment_method(setup_future_usage: 'off_session', auto_capture: false)
     @payment_method = create(
-      :stripe_payment_method,
+      :solidus_stripe_payment_method,
       preferred_setup_future_usage: setup_future_usage,
       auto_capture: auto_capture
     )

--- a/spec/support/solidus_stripe/webhook/event_with_context_factory.rb
+++ b/spec/support/solidus_stripe/webhook/event_with_context_factory.rb
@@ -59,7 +59,7 @@ module SolidusStripe
 
       def solidus_stripe_object
         @solidus_stripe_object = SolidusStripe::Webhook::Event.new(stripe_event: stripe_object,
-          spree_payment_method: @payment_method)
+          payment_method: @payment_method)
       end
 
       def json

--- a/spec/system/backend/solidus_stripe/orders/payments_spec.rb
+++ b/spec/system/backend/solidus_stripe/orders/payments_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'SolidusStripe Orders Payments', :js do
     end
 
     it 'displays log entries for a payment' do
-      payment = create(:stripe_payment, :captured, order: order, payment_method: payment_method)
+      payment = create(:solidus_stripe_payment, :captured, order: order, payment_method: payment_method)
 
       visit_payment_page(payment)
 


### PR DESCRIPTION
## Summary

We're making naming more consistent:

### Rename `Event#spree_payment_method` to `Event#payment_method`

We're using the prefix-less version for the Solidus payment method elsewhere.

### Prefix factories with `:solidus_stripe` instead of `:stripe`

Having something like `build(:stripe_payment_method)` can be confusing because Stripe also has a different Payment Method entity. We're now renaming the factory for `SolidusStripe::PaymentMethod` instances to `:solidus_stripe_payment_method`, and using the same prefix for all other factories for consistency.

### Rename `:order_with_stripe_payment` factory to `:solidus_stripe_order`

That's to be consistent with all the other factories, which are prefixed with `solidus_stripe`.

### Prefix Stripe refund references with `:stripe_`

### Prepend references to Stripe payment intents with `:stripe_`

Closes #283 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
