### PR TITLE
Tweaks about refunds sync

### DIFF
--- a/app/models/solidus_stripe/gateway.rb
+++ b/app/models/solidus_stripe/gateway.rb
@@ -168,9 +168,7 @@ module SolidusStripe
         Stripe::Refund.create(
           amount: to_stripe_amount(amount_in_cents, currency),
           payment_intent: stripe_payment_intent_id,
-          metadata: {
-            RefundsSynchronizer::SKIP_SYNC_METADATA_KEY => RefundsSynchronizer::SKIP_SYNC_METADATA_VALUE
-          }
+          metadata: RefundsSynchronizer.skip_sync_metadata
         )
       end
 

--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -54,10 +54,8 @@ module SolidusStripe
       payment = @payment_method.payments.find_by!(response_code: stripe_payment_intent_id)
 
       stripe_refunds(stripe_payment_intent_id)
-        .select(&method(:stripe_refund_needs_sync?))
-        .map(
-          &method(:create_refund).curry[payment]
-        )
+        .select { stripe_refund_needs_sync?(_1) }
+        .map { create_refund(payment, _1) }
     end
 
     private
@@ -81,7 +79,7 @@ module SolidusStripe
         amount: refund_decimal_amount(stripe_refund),
         transaction_id: stripe_refund.id,
         reason: SolidusStripe::PaymentMethod.refund_reason
-      ).tap(&method(:log_refund).curry[payment])
+      ).tap { log_refund(payment, _1) }
     end
 
     def log_refund(payment, refund)

--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -32,13 +32,17 @@ module SolidusStripe
   class RefundsSynchronizer
     include MoneyToStripeAmountConverter
 
-    # Metadata key used to mark refunds that shouldn't be synced back to Solidus.
-    # @return [Symbol]
     SKIP_SYNC_METADATA_KEY = :solidus_skip_sync
+    private_constant :SKIP_SYNC_METADATA_KEY
 
-    # Metadata value used to mark refunds that shouldn't be synced back to Solidus.
-    # @return [String]
     SKIP_SYNC_METADATA_VALUE = 'true'
+    private_constant :SKIP_SYNC_METADATA_VALUE
+
+    # Metadata used to mark Stripe refunds that shouldn't be synced back to Solidus.
+    # @return [Hash]
+    def self.skip_sync_metadata
+      { SKIP_SYNC_METADATA_KEY => SKIP_SYNC_METADATA_VALUE }
+    end
 
     # @param payment_method [SolidusStripe::PaymentMethod]
     def initialize(payment_method)

--- a/lib/solidus_stripe/refunds_synchronizer.rb
+++ b/lib/solidus_stripe/refunds_synchronizer.rb
@@ -47,7 +47,7 @@ module SolidusStripe
 
     # @param stripe_payment_intent_id [String]
     def call(stripe_payment_intent_id)
-      payment = Spree::Payment.find_by!(response_code: stripe_payment_intent_id)
+      payment = @payment_method.payments.find_by!(response_code: stripe_payment_intent_id)
 
       stripe_refunds(stripe_payment_intent_id)
         .select(&method(:stripe_refund_needs_sync?))


### PR DESCRIPTION
## Summary

This PR is a result of a [post-merge review](https://github.com/solidusio/solidus_stripe/pull/281#issuecomment-1511470637) on #281.

- Scope searching refunds to the payment method when syncing
- Hide concrete details about the needed metadata to skip refunds sync
- Use more standard Ruby

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
