### PR TITLE
Allow the use of non-card Stripe payment methods

### DIFF
--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -5,17 +5,9 @@ module SolidusStripe
     belongs_to :order, class_name: 'Spree::Order'
     belongs_to :payment_method, class_name: 'SolidusStripe::PaymentMethod'
 
-    def self.prepare_for_payment(payment, **stripe_intent_options)
+    def self.prepare_for_payment(payment, **stripe_creation_options)
       # Find or create the intent for the payment.
-      intent =
-        retrieve_last_usable_intent(payment) ||
-          new(payment_method: payment.payment_method, order: payment.order)
-            .tap { _1.update!(stripe_intent_id: _1.create_stripe_intent(**stripe_intent_options).id) }
-
-      # Update the intent with the previously acquired payment method.
-      intent.payment_method.gateway.request {
-        Stripe::PaymentIntent.update(intent.stripe_intent_id, payment_method: payment.source.stripe_payment_method_id)
-      }
+      intent = retrieve_for_payment(payment) || create_for_payment(payment, **stripe_creation_options)
 
       # Attach the payment intent to the payment.
       payment.update!(response_code: intent.stripe_intent.id)
@@ -23,9 +15,26 @@ module SolidusStripe
       intent
     end
 
-    def self.retrieve_last_usable_intent(payment)
+    def self.create_for_payment(payment, **stripe_intent_options)
+      new(payment_method: payment.payment_method, order: payment.order)
+        .tap { _1.update!(stripe_intent_id: _1.create_stripe_intent(payment, **stripe_intent_options).id) }
+    end
+
+    def self.retrieve_for_payment(payment)
       intent = where(payment_method: payment.payment_method, order: payment.order).last
-      intent if intent&.usable?
+
+      return unless intent&.usable?
+
+      # Update the intent with the previously acquired payment method.
+      intent.payment_method.gateway.request {
+        Stripe::PaymentIntent.update(
+          intent.stripe_intent_id,
+          payment_method: payment.source.stripe_payment_method_id,
+          payment_method_types: [payment.source.stripe_payment_method.type],
+        )
+      }
+
+      intent
     end
 
     def usable?
@@ -89,7 +98,7 @@ module SolidusStripe
       super
     end
 
-    def create_stripe_intent(**stripe_intent_options)
+    def create_stripe_intent(payment, **stripe_intent_options)
       stripe_customer_id = SolidusStripe::Customer.retrieve_or_create_stripe_customer_id(
         payment_method: payment_method,
         order: order
@@ -102,6 +111,8 @@ module SolidusStripe
           capture_method: payment_method.auto_capture? ? 'automatic' : 'manual',
           setup_future_usage: payment_method.preferred_setup_future_usage.presence,
           customer: stripe_customer_id,
+          payment_method: payment.source.stripe_payment_method_id,
+          payment_method_types: [payment.source.stripe_payment_method.type],
           metadata: { solidus_order_number: order.number },
           **stripe_intent_options,
         })

--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -59,6 +59,8 @@ module SolidusStripe
       payment.started_processing!
 
       case stripe_intent.status
+      when 'processing'
+        successful = true
       when 'requires_capture'
         payment.pend! unless payment.pending?
         successful = true

--- a/app/views/spree/admin/payments/source_forms/existing_payment/_stripe.html.erb
+++ b/app/views/spree/admin/payments/source_forms/existing_payment/_stripe.html.erb
@@ -9,6 +9,11 @@
 
 <div>
   <label>
-    <%= render "#{partial_base}/#{payment_type}", stripe_payment_method: stripe_payment_method %>
+    <%= render(
+      "#{partial_base}/#{payment_type}",
+      stripe_payment_method: stripe_payment_method,
+      partial_base: partial_base,
+      payment_type: payment_type
+    ) %>
   </label>
 </div>

--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_payment_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_payment_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
   static values = {
     clientSecret: String,
     publishableKey: String,
-    paymentElementOptions: Object,
+    options: Object,
 
     // For now we don't have a controller to interact with
     // and we can't use outlets, so we fallback on acquiring selectors.
@@ -71,8 +71,8 @@ export default class extends Controller {
   }
 
   setupPaymentElement() {
-    this.elements = this.stripe.elements(this.paymentElementOptionsValue)
-    this.paymentElement = this.elements.create("payment", { layout: "tabs" })
+    this.elements = this.stripe.elements(this.optionsValue.elementsInitialization)
+    this.paymentElement = this.elements.create("payment", this.optionsValue.paymentElementCreation)
     this.paymentElementTarget.innerHTML = "" // Remove child nodes used for loading
     this.paymentElement.mount(this.paymentElementTarget)
   }

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/existing_payment/_stripe.html.erb
@@ -11,6 +11,11 @@
 
 <div>
   <label>
-    <%= render "#{partial_base}/#{payment_type}", stripe_payment_method: stripe_payment_method %>
+    <%= render(
+      "#{partial_base}/#{payment_type}",
+      stripe_payment_method: stripe_payment_method,
+      partial_base: partial_base,
+      payment_type: payment_type,
+    ) %>
   </label>
 </div>

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -1,22 +1,57 @@
-<% payment_element_options = {
-  mode: 'payment',
-  amount: SolidusStripe::MoneyToStripeAmountConverter.to_stripe_amount(
-    current_order.display_order_total_after_store_credit.money.fractional,
-    current_order.currency,
-  ),
-  currency: current_order.currency.downcase,
-  paymentMethodCreation: 'manual',
-  captureMethod: payment_method.auto_capture? ? 'automatic' : 'manual',
-  # Fully customizable with appearance API.
-  # https://stripe.com/docs/elements/appearance-api
-  # appearance: {},
-} %>
+<%
+  bill_address = current_order.bill_address
+  options = {
+    elementsInitialization: {
+      mode: 'payment',
+      amount: SolidusStripe::MoneyToStripeAmountConverter.to_stripe_amount(
+        current_order.display_order_total_after_store_credit.money.fractional,
+        current_order.currency,
+      ),
+      currency: current_order.currency.downcase,
+      paymentMethodCreation: 'manual',
+      captureMethod: payment_method.auto_capture? ? 'automatic' : 'manual',
+
+      # If you want to allow the display/use of specific payment method types
+      # activated from the Stripe Dashboard, you can use this option.
+      #
+      # For a complete list of payment method types available on Stripe:
+      # https://stripe.com/docs/payments/payment-methods/overview
+      # https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+      #
+      # To activate/deactivate Stripe payment methods:
+      # https://dashboard.stripe.com/settings/payment_methods
+      # paymentMethodTypes: ['card', 'sepa_debit'],
+
+      # Fully customizable with appearance API.
+      # https://stripe.com/docs/elements/appearance-api
+      # appearance: {},
+    },
+    paymentElementCreation: {
+      layout: "tabs",
+      defaultValues: {
+        billingDetails: {
+          name: bill_address.name,
+          email: current_order.email,
+          phone: bill_address.phone,
+          address: {
+            line1: bill_address.address1,
+            line2: bill_address.address2,
+            city: bill_address.city,
+            state: bill_address.state.abbr,
+            country: bill_address.country.iso,
+            postal_code: bill_address.zipcode,
+          }
+        }
+      },
+    },
+  }
+ %>
 
 <div
   class="solidus-stripe-payment"
   data-controller="solidus-stripe-payment"
   data-solidus-stripe-payment-publishable-key-value="<%= payment_method.preferred_publishable_key %>"
-  data-solidus-stripe-payment-payment-element-options-value="<%= payment_element_options.to_json %>"
+  data-solidus-stripe-payment-options-value="<%= options.to_json %>"
   data-solidus-stripe-payment-radio-selector-value="#order_payments_attributes__payment_method_id_<%= payment_method.id %>"
   data-solidus-stripe-payment-submit-selector-value="#checkout_form_payment [type='submit']"
   data-action="submit@window->solidus-stripe-payment#handleSubmit"

--- a/lib/generators/solidus_stripe/install/templates/app/views/orders/payment_info/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/orders/payment_info/_stripe.html.erb
@@ -1,7 +1,19 @@
-<% stripe_payment_method = payment.source.stripe_payment_method %>
+<%
+  stripe_payment_method = payment.source.stripe_payment_method
+
+  # https://stripe.com/docs/api/payment_methods/object#payment_method_object-type
+  partial_base = "checkouts/existing_payment/stripe"
+  payment_type = stripe_payment_method.type
+
+  # Fallback on the default partial if a specialized partial is not available.
+  payment_type = 'default' if lookup_context.find_all("#{partial_base}/_#{payment_type}").none?
+%>
+
 <%= render(
-  "checkouts/existing_payment/stripe/#{stripe_payment_method.type}",
-  stripe_payment_method: stripe_payment_method
+  "#{partial_base}/#{payment_type}",
+  stripe_payment_method: stripe_payment_method,
+  partial_base: partial_base,
+  payment_type: payment_type
 ) %>
 
 <% if current_order&.confirm? %>

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe 'SolidusStripe Checkout', :js do
     end
   end
 
+  context 'with non-card Stripe payment methods' do
+    before do
+      stub_spree_preferences(currency: 'EUR')
+      create_payment_method(setup_future_usage: 'off_session', auto_capture: true)
+    end
+
+    it 'creates a payment intent and successfully processes sepa_debit payment' do
+      visit_payment_step(user: create(:user))
+      choose_new_stripe_payment
+      choose_stripe_payment_method(payment_method_type: "sepa_debit")
+      fills_in_stripe_input 'iban', with: 'DE89370400440532013000'
+
+      submit_payment
+      complete_order
+
+      expects_payment_to_be_processing
+    end
+  end
+
   context 'with declined cards' do
     it 'reject transactions with cards declined at intent creation or invalid fields and return an appropriate response' do # rubocop:disable Layout/LineLength
       create_payment_method


### PR DESCRIPTION
## Summary

- Fixes #300
- Fixes #263
- Documentation for this is already covered by #208
- Fixes #175 

The goal of these changes is to see the supported and enabled Stripe payment methods in the checkout payment section and be able to use them (even without a dedicated configuration like dedicated partial views for payment method types).

Please look at the attached issues and all the commit details for more context.

### Testing

https://user-images.githubusercontent.com/19948291/234878333-9c177079-a25f-4f57-850f-7f71700ac5f3.mov

In case of manual tests, be sure to:
1. _Activate the payment methods_ you want to test from the [Stripe Dashboard](https://dashboard.stripe.com/test/settings/payment_methods).
2. Set the `Auto Capture` mode to `Yes` in your Solidus Stripe Payment Method:
This is needed to allow the display of non-card payment methods that don't support `capture_mode` set to `false`: Most of the Stripe payment methods have this behavior.
3. _Have the correct currency_ based on your Stripe Country account: For example, if my Stripe account is configured in "IT" I will probably need an order with "EUR" currency to display some of the activated payment methods.
4. Try to use a _Stripe Payment Method that is supported in the country_ (otherwise, it won't be displayed).


Please refer to the [Stripe documentation](https://stripe.com/docs/payments/payment-methods/integration-options#additional-api-bank-debits) to better understand all the settings needed to display and use a specific Stripe payment method.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
