### PR TITLE
Fix `solidus_gateway` to `solidus_stripe` preference migration (v4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,29 +14,38 @@ executors:
   sqlite:
     description: Run specs with an SQLite
     docker:
-      - image: cimg/ruby:2.7-browsers
+      - image: cimg/ruby:3.0-browsers
         environment:
           RAILS_ENV: test
           DB: sqlite
 
 jobs:
   run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+    executor:
+      name: solidusio_extensions/postgres
+      ruby_version: "3.0"
     steps:
+      - checkout
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
+    executor:
+      name: solidusio_extensions/mysql
+      ruby_version: "3.0"
     steps:
+      - checkout
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   run-specs-with-sqlite:
     executor: sqlite
     steps:
+      - checkout
       - browser-tools/install-chrome
       - solidusio_extensions/run-tests
   lint-code:
-    executor: solidusio_extensions/sqlite-memory
+    executor:
+      name: solidusio_extensions/sqlite-memory
+      ruby_version: "3.0"
     steps:
       - solidusio_extensions/lint-code
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,9 @@ orbs:
   # Required for feature specs.
   browser-tools: circleci/browser-tools@1.1
 
-  # Always take the latest version of the orb, this allows us to
-  # run specs against Solidus supported versions only without the need
-  # to change this configuration every time a Solidus version is released
-  # or goes EOL.
-  solidusio_extensions: solidusio/extensions@volatile
+  # The orb version v0.7.3 until Solidus 3.4, which is the last version of
+  # Solidus that v4 of `solidus_stripe` can reasonably support.
+  solidusio_extensions: solidusio/extensions@0.7.3
 
 executors:
   sqlite:
@@ -27,7 +25,8 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-chrome
-      - solidusio_extensions/run-tests
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
   run-specs-with-mysql:
     executor:
       name: solidusio_extensions/mysql
@@ -35,19 +34,15 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-chrome
-      - solidusio_extensions/run-tests
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
   run-specs-with-sqlite:
     executor: sqlite
     steps:
       - checkout
       - browser-tools/install-chrome
-      - solidusio_extensions/run-tests
-  lint-code:
-    executor:
-      name: solidusio_extensions/sqlite-memory
-      ruby_version: "3.0"
-    steps:
-      - solidusio_extensions/lint-code
+      - solidusio_extensions/run-tests-solidus-older
+      - solidusio_extensions/run-tests-solidus-current
 
 workflows:
   "Run specs on supported Solidus versions":
@@ -55,16 +50,3 @@ workflows:
       - run-specs-with-postgres
       - run-specs-with-mysql
       - run-specs-with-sqlite
-      - lint-code
-
-  "Weekly run specs against master":
-    triggers:
-      - schedule:
-          cron: "0 0 * * 4" # every Thursday
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql

--- a/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
+++ b/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
@@ -4,7 +4,7 @@ class UpdateStripePaymentMethodTypeToCreditCard < SolidusSupport::Migration[5.1]
   def up
     Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway').update_all(type: 'Spree::PaymentMethod::StripeCreditCard')
 
-    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/gateway/stripe_gateway'").each do |pref|
+    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/gateway/stripe_gateway%'").each do |pref|
       pref.key = pref.key.gsub('spree/gateway/stripe_gateway', 'spree/payment_method/stripe_credit_card')
       pref.save
     end
@@ -13,7 +13,7 @@ class UpdateStripePaymentMethodTypeToCreditCard < SolidusSupport::Migration[5.1]
   def down
     Spree::PaymentMethod.where(type: 'Spree::PaymentMethod::StripeCreditCard').update_all(type: 'Spree::Gateway::StripeGateway')
 
-    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/payment_method/stripe_credit_card'").each do |pref|
+    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/payment_method/stripe_credit_card%'").each do |pref|
       pref.key = pref.key.gsub('spree/payment_method/stripe_credit_card', 'spree/gateway/stripe_gateway')
       pref.save
     end

--- a/lib/solidus_stripe/version.rb
+++ b/lib/solidus_stripe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusStripe
-  VERSION = '4.4.0'
+  VERSION = '4.4.1'
 end

--- a/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
+++ b/spec/models/solidus_stripe/create_intents_payment_service_spec.rb
@@ -102,7 +102,11 @@ RSpec.describe SolidusStripe::CreateIntentsPaymentService do
       end
 
       before do
-        response = double(success?: true, authorization: payment.response_code)
+        response = ActiveMerchant::Billing::Response.new(true, '', {}, {
+            authorization: payment.response_code,
+            avs_result: {"code": "avs-code"},
+            cvv_esult: {"code": "cvv-code", "message": "CVV result"}
+          })
         allow_any_instance_of(Spree::PaymentMethod::StripeCreditCard).to receive(:void) { response }
       end
 

--- a/spec/models/spree/payment_method/stripe_credit_card_spec.rb
+++ b/spec/models/spree/payment_method/stripe_credit_card_spec.rb
@@ -262,10 +262,11 @@ describe Spree::PaymentMethod::StripeCreditCard do
     end
 
     let!(:success_response) do
-      double('success_response', success?: true,
-                               authorization: '123',
-                               avs_result: { 'code' => 'avs-code' },
-                               cvv_result: { 'code' => 'cvv-code', 'message' => "CVV Result" })
+      ActiveMerchant::Billing::Response.new(true, '', {}, {
+        authorization: '123',
+        avs_result: {"code": "avs-code"},
+        cvv_esult: {"code": "cvv-code", "message": "CVV result"}
+      })
     end
 
     after do


### PR DESCRIPTION
## Summary

This pull request resolves #273 for v4 of the `solidus_stripe` extension.

It edits a migration. The migration as written did not not successfully migrate payment method preferences that were created with `solidus_gateway` to preferences for use with `solidus_stripe`.

## Checklist
The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
