### PR TITLE
Fix `solidus_gateway` to `solidus_stripe` preference migration (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,30 @@
 # Changelog
 
-## [Unreleased](https://github.com/solidusio/solidus_stripe/tree/HEAD)
+## [v3.2.2](https://github.com/solidusio/solidus_stripe/tree/v3.2.2)
 
-[Full Changelog](https://github.com/solidusio/solidus_stripe/compare/v3.0.0...HEAD)
+[Full Changelog](https://github.com/solidusio/solidus_stripe/compare/v3.2.1...v3.2.2)
+
+This release updates a pre-existing migration. If you're migrating from
+`solidus_gateway`'s Stripe payment method to `solidus_stripe` and ran migrations
+before this release, you may have orphaned `Spree::Preference` records related
+to the legacy `solidus_gateway` Stripe payment methods. You probably fixed this
+manually or created brand new payment method records to use in production. You
+can effectively ignore this patch release.
+
+If you're installing v4 of this extension for the first time, the migration will
+now run as intended.
+
+**Fixed bugs:**
+
+- Fixed legacy migration for migrating `Spree::Preference` data from `solidus_gateway` to `solidus_stripe` [\#298](https://github.com/solidusio/solidus_stripe/pull/298) ([benjaminwil](https://github.com/benjaminwil))
+
+## [v3.2.1](https://github.com/solidusio/solidus_stripe/tree/v3.2.1)
+
+[Full Changelog](https://github.com/solidusio/solidus_stripe/compare/v3.2.0...v3.2.1)
+
+## [v3.2.0](https://github.com/solidusio/solidus_stripe/tree/v3.2.0)
+
+[Full Changelog](https://github.com/solidusio/solidus_stripe/compare/v3.0.0...v3.2.0)
 
 **Fixed bugs:**
 

--- a/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
+++ b/db/migrate/20181010123508_update_stripe_payment_method_type_to_credit_card.rb
@@ -4,7 +4,7 @@ class UpdateStripePaymentMethodTypeToCreditCard < SolidusSupport::Migration[5.1]
   def up
     Spree::PaymentMethod.where(type: 'Spree::Gateway::StripeGateway').update_all(type: 'Spree::PaymentMethod::StripeCreditCard')
 
-    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/gateway/stripe_gateway'").each do |pref|
+    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/gateway/stripe_gateway%'").each do |pref|
       pref.key = pref.key.gsub('spree/gateway/stripe_gateway', 'spree/payment_method/stripe_credit_card')
       pref.save
     end
@@ -13,7 +13,7 @@ class UpdateStripePaymentMethodTypeToCreditCard < SolidusSupport::Migration[5.1]
   def down
     Spree::PaymentMethod.where(type: 'Spree::PaymentMethod::StripeCreditCard').update_all(type: 'Spree::Gateway::StripeGateway')
 
-    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/payment_method/stripe_credit_card'").each do |pref|
+    Spree::Preference.where("#{ActiveRecord::Base.connection.quote_column_name('key')} LIKE 'spree/payment_method/stripe_credit_card%'").each do |pref|
       pref.key = pref.key.gsub('spree/payment_method/stripe_credit_card', 'spree/gateway/stripe_gateway')
       pref.save
     end

--- a/lib/solidus_stripe/version.rb
+++ b/lib/solidus_stripe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusStripe
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
## Summary

This pull request resolves #273 for v3 of the `solidus_stripe` extension.

It edits a migration. The migration as written did not not successfully migrate payment method preferences that were created with `solidus_gateway` to preferences for use with `solidus_stripe`.

## Checklist
The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
