### PR TITLE
Add missing `&&` in `SolidusStripe::PaymentIntent.usable?`

### DIFF
--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -30,7 +30,7 @@ module SolidusStripe
 
     def usable?
       stripe_intent_id &&
-      stripe_intent.status == 'requires_payment_method'
+      stripe_intent.status == 'requires_payment_method' &&
       stripe_intent.amount == stripe_order_amount
     end
 

--- a/spec/models/solidus_stripe/payment_intent_spec.rb
+++ b/spec/models/solidus_stripe/payment_intent_spec.rb
@@ -14,4 +14,65 @@ RSpec.describe SolidusStripe::PaymentIntent do
       expect(intent.stripe_intent.object_id).not_to eq(intent.reload.stripe_intent.object_id)
     end
   end
+
+  describe '.usable?' do
+    context 'when the Stripe intent is usable' do
+      it 'returns true' do
+        payment_intent = create(:solidus_stripe_payment_intent, order: create(:order_with_line_items))
+        status = 'requires_payment_method'
+        stripe_intent = Stripe::PaymentIntent.construct_from(
+          id: payment_intent.stripe_intent_id,
+          amount: payment_intent.stripe_order_amount,
+          status: status
+        )
+
+        allow(payment_intent).to receive(:stripe_intent).and_return(stripe_intent)
+
+        expect(payment_intent).to be_usable
+      end
+    end
+
+    context 'when the Stripe intent ID is nil' do
+      it 'returns false' do
+        payment_intent = create(:solidus_stripe_payment_intent,
+          order: create(:order_with_line_items),
+          stripe_intent_id: nil)
+
+        expect(payment_intent).not_to be_usable
+      end
+    end
+
+    context 'when the Stripe intent status is not "requires_payment_method"' do
+      it 'returns false' do
+        payment_intent = create(:solidus_stripe_payment_intent, order: create(:order_with_line_items))
+        status = 'requires_action'
+        stripe_intent = Stripe::PaymentIntent.construct_from(
+          id: payment_intent.stripe_intent_id,
+          amount: payment_intent.stripe_order_amount,
+          status: status
+        )
+
+        allow(payment_intent).to receive(:stripe_intent).and_return(stripe_intent)
+
+        expect(payment_intent).not_to be_usable
+      end
+    end
+
+    context 'when the Stripe intent amount is different from the order amount' do
+      it 'returns false' do
+        payment_intent = create(:solidus_stripe_payment_intent, order: create(:order_with_line_items))
+        status = 'requires_payment_method'
+        amount = payment_intent.stripe_order_amount + 1
+        stripe_intent = Stripe::PaymentIntent.construct_from(
+          id: payment_intent.stripe_intent_id,
+          amount: amount,
+          status: status
+        )
+
+        allow(payment_intent).to receive(:stripe_intent).and_return(stripe_intent)
+
+        expect(payment_intent).not_to be_usable
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->
This PR fixes a typo within the mentioned method where the condition is currently not fully working due to a missing `&&`.

Refer to this commit: https://github.com/solidusio/solidus_stripe/commit/33b0ad4e7017693aeaaedbeedaaf2911682d6416 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
