### PR TITLE
Allow finalizing an order if fully covered by store credits

### DIFF
--- a/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_payment_controller.js
+++ b/lib/generators/solidus_stripe/install/templates/app/javascript/controllers/solidus_stripe_payment_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     // and we can't use outlets, so we fallback on acquiring selectors.
     submitSelector: String,
     radioSelector: String,
+    isCoveredByStoreCredit: Boolean,
   }
 
   static targets = ["paymentElement", "message", "paymentMethodInput"]
@@ -24,8 +25,12 @@ export default class extends Controller {
   }
 
   async connect() {
-    this.stripe = await loadStripe(this.publishableKeyValue)
-    this.setupPaymentElement()
+    if (this.isCoveredByStoreCreditValue) {
+      this.messageTarget.textContent = "Free orders are not supported."
+    } else {
+      this.stripe = await loadStripe(this.publishableKeyValue)
+      this.setupPaymentElement()
+    }
   }
 
   // @action
@@ -35,6 +40,8 @@ export default class extends Controller {
 
     // Bail out if the current payment method is not selected.
     if (!this.radioOutletElement.checked) return
+
+    if (this.isCoveredByStoreCreditValue) return
 
     e.preventDefault()
 

--- a/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
+++ b/lib/generators/solidus_stripe/install/templates/app/views/checkouts/payment/_stripe.html.erb
@@ -54,6 +54,7 @@
   data-solidus-stripe-payment-options-value="<%= options.to_json %>"
   data-solidus-stripe-payment-radio-selector-value="#order_payments_attributes__payment_method_id_<%= payment_method.id %>"
   data-solidus-stripe-payment-submit-selector-value="#checkout_form_payment [type='submit']"
+  data-solidus-stripe-payment-is-covered-by-store-credit-value="<%= current_order.covered_by_store_credit? %>"
   data-action="submit@window->solidus-stripe-payment#handleSubmit"
 >
   <input


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Fixes #307


This temporary fix enables the finalization of orders entirely covered by store credits or adjustments, but it can't be a permanent solution.

The main "issue" relates to Stirpe, which does not allow a 0$ charge because the minimum amount needed to perform the operation isn't met:
https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts

Various alternative strategies could be followed:
- One option could be to hide the [payment method from the frontend interface](https://github.com/solidusio/solidus_starter_frontend/blob/b9a02e197e8e6ea0aa0b1c9695a18d2b010e21c6/templates/app/views/checkouts/steps/_payment_step.html.erb#L35).
- Map the minimum amounts of all the mentioned currencies and perform a payment with that amount in case of orders fully covered by store credits/adjustments
- Another possibility is to integrate a structure into the `Spree::PaymentMethod` that can prevent a payment method from appearing among the choices available for an order in `available_payment_methods`.

ℹ️ Touching the [`payment_required?`](https://github.com/solidusio/solidus/blob/474877aaad9139a0a9b8564a9e7279e5446bc12c/core/app/models/spree/order.rb#L244-L246) method on `Spree::Order` is something I didn't consider as it would prevent the processing of payments and possibly even the applied store credits, but I haven't looked into that so much, so let me know.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.

# Screenshots
![May-25-2023 17-29-00](https://github.com/solidusio/solidus_stripe/assets/19948291/984ee068-e6e2-45a5-8cea-1502264d4d3a)
<img width="1348" alt="Screenshot 2023-05-25 at 17 29 31" src="https://github.com/solidusio/solidus_stripe/assets/19948291/d96d0e18-a31e-4d1f-92fc-ddea717a9086">

