### PR TITLE
Ensure the order tabs are not collapsed into a drop down

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,7 @@ task :default do
     sh 'bin/rspec'
   end
 end
+
+require 'rake/clean'
+CLOBBER.include('tmp/cache/rails-new')
+CLOBBER.include('dummy-app')

--- a/bin/dummy-app
+++ b/bin/dummy-app
@@ -22,8 +22,5 @@ echo "gem 'simplecov', '~> 0.22', require: false" >> Gemfile
 echo "gem 'simplecov-cobertura', require: false" >> Gemfile
 unbundled bundle install
 
-unbundled bundle add solidus --github solidusio/solidus --branch "${SOLIDUS_BRANCH:-main}" --version '> 0.a'
-unbundled bundle exec rake db:drop db:create
-unbundled bundle exec rails generate solidus:install --auto-accept --payment-method=none --no-seed --no-sample "$@"
 unbundled bundle add $extension_name --path ..
 unbundled bundle exec rails generate $extension_name:install --migrate --load-seeds=false --specs=all

--- a/bin/rails-new
+++ b/bin/rails-new
@@ -11,6 +11,8 @@ rails_version=`bundle exec ruby -rrails/version -e'puts Rails.version'`
 solidus_version=`bundle exec ruby -rspree/core/version -e'puts Spree::VERSION'`
 cache_path="tmp/cache/rails-new/${app_name}-${rails_version}-${solidus_version}-${ruby_version}.zip"
 
+test $CI && cache_path="" # Disable caching on CI
+
 # Stay away from the bundler env of the containing extension.
 function unbundled {
   echo "~~> Running: $@"

--- a/spec/support/solidus_stripe/backend_test_helper.rb
+++ b/spec/support/solidus_stripe/backend_test_helper.rb
@@ -117,6 +117,7 @@ module SolidusStripe::BackendTestHelper
   def complete_order_with_existing_payment_source
     visit_payments_page
     click_on "Continue"
+    page.current_window.resize_to(1200, 800)
     click_on "Confirm"
     click_on "Complete Order"
   end

--- a/spec/support/solidus_stripe/backend_test_helper.rb
+++ b/spec/support/solidus_stripe/backend_test_helper.rb
@@ -70,7 +70,14 @@ module SolidusStripe::BackendTestHelper
 
   def visit_payment_page(payment)
     visit_payments_page
-    click_on payment.number
+    click_on_payment(payment)
+  end
+
+  def click_on_payment(payment)
+    payment_number_link = find_link(payment.number)
+    page.current_window.resize_to(1200, 800)
+    scroll_to payment_number_link
+    payment_number_link.click
   end
 
   # Action helper methods for performing operations on payments

--- a/spec/system/backend/solidus_stripe/orders/payments_spec.rb
+++ b/spec/system/backend/solidus_stripe/orders/payments_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe 'SolidusStripe Orders Payments', :js do
     it 'navigates to the payments page' do
       payment = create_authorized_payment
       visit_payments_page
-
-      click_on 'Payments'
+      within('[data-hook="admin_order_tabs"]') do
+        payments_link = find_link('Payments')
+        scroll_to payments_link
+        page.current_window.resize_to(1200, 800)
+        payments_link.click
+      end
       expect(page).to have_content(payment.number)
     end
 


### PR DESCRIPTION
## Summary

The "Payments" tab in the admin order page was collapsed if the browser width was too narrow.
Also required https://github.com/solidusio/solidus/pull/5423 to be merged to fix content ending up under the sidebar.

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
