### PR TITLE
Ensure reloading the confirmation page doesn't break the checkout

### DIFF
--- a/app/models/solidus_stripe/payment_intent.rb
+++ b/app/models/solidus_stripe/payment_intent.rb
@@ -39,7 +39,8 @@ module SolidusStripe
 
     def usable?
       stripe_intent_id &&
-      stripe_intent.status == 'requires_payment_method' &&
+      (stripe_intent.status == 'requires_payment_method' ||
+        stripe_intent.status == 'requires_confirmation') &&
       stripe_intent.amount == stripe_order_amount
     end
 

--- a/spec/system/frontend/solidus_stripe/checkout_spec.rb
+++ b/spec/system/frontend/solidus_stripe/checkout_spec.rb
@@ -203,4 +203,23 @@ RSpec.describe 'SolidusStripe Checkout', :js do
       end
     end
   end
+
+  context 'when refreshing the confirmation page' do
+    it 'does not create a duplicate payment intent' do
+      create_payment_method
+      visit_payment_step(user: create(:user))
+      choose_new_stripe_payment
+      fill_in_stripe_country('United States')
+      fill_stripe_form(number: '4000000000003220')
+      submit_payment
+      expect(page).to have_content('Confirm')
+      check_terms_of_service # ensure we're on the confirm page before refreshing
+      page.driver.browser.navigate.refresh
+      check_terms_of_service
+      confirm_order
+      authorize_3d_secure_2_payment(authenticate: true)
+      expect(page).to have_content('Your order has been processed successfully')
+      payment_intent_is_created_with_required_capture
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Looks like we missed this pattern in which a payment intent state was advanced while rendering the confirmation page.
Adding support for this state ensures we don't get a 500 by simply refreshing the confirmation page.
<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
