### PR TITLE
Bug Fix: Register Webhook Event Only Once

### DIFF
--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -18,11 +18,13 @@ module SolidusStripe
 
     initializer "solidus_stripe.pub_sub", after: "spree.core.pub_sub" do |app|
       require "solidus_stripe/webhook/event"
+
+      SolidusStripe::Webhook::Event.register(
+        user_events: SolidusStripe.configuration.webhook_events,
+        bus: Spree::Bus
+      )
+
       app.reloader.to_prepare do
-        SolidusStripe::Webhook::Event.register(
-          user_events: SolidusStripe.configuration.webhook_events,
-          bus: Spree::Bus
-        )
         SolidusStripe::Webhook::PaymentIntentSubscriber.new.subscribe_to(Spree::Bus)
         SolidusStripe::Webhook::ChargeSubscriber.new.subscribe_to(Spree::Bus)
       end


### PR DESCRIPTION
Prior to this change, an error would be thrown every time Rails would have to reload because SolidusStripe would try to re-register the webhook events. To prevent this we want to remove the registration call outside of the reloader so it only registers the event once.

