### PR TITLE
Revert "Bug Fix: Register Webhook Event Only Once"

### DIFF
--- a/lib/solidus_stripe/engine.rb
+++ b/lib/solidus_stripe/engine.rb
@@ -18,13 +18,11 @@ module SolidusStripe
 
     initializer "solidus_stripe.pub_sub", after: "spree.core.pub_sub" do |app|
       require "solidus_stripe/webhook/event"
-
-      SolidusStripe::Webhook::Event.register(
-        user_events: SolidusStripe.configuration.webhook_events,
-        bus: Spree::Bus
-      )
-
       app.reloader.to_prepare do
+        SolidusStripe::Webhook::Event.register(
+          user_events: SolidusStripe.configuration.webhook_events,
+          bus: Spree::Bus
+        )
         SolidusStripe::Webhook::PaymentIntentSubscriber.new.subscribe_to(Spree::Bus)
         SolidusStripe::Webhook::ChargeSubscriber.new.subscribe_to(Spree::Bus)
       end


### PR DESCRIPTION
Reverts solidusio/solidus_stripe#318

Reverting since the CI failed on `main`, we need to look into this further.

cc @cpfergus1 