### PR TITLE
Install routes where Solidus lives

### DIFF
--- a/lib/generators/solidus_stripe/install/install_generator.rb
+++ b/lib/generators/solidus_stripe/install/install_generator.rb
@@ -32,7 +32,7 @@ module SolidusStripe
       def install_solidus_core_support
         support_code_for(:core) do
           directory 'config/initializers', 'config/initializers'
-          route "mount SolidusStripe::Engine, at: '/solidus_stripe'"
+          route "mount SolidusStripe::Engine, at: '#{solidus_mount_point}solidus_stripe'"
         end
       end
 
@@ -130,6 +130,12 @@ module SolidusStripe
         else
           say_status :skip, "[#{engine.engine_name}] solidus_#{component_name}", :blue
         end
+      end
+
+      def solidus_mount_point
+        mount_point = Spree::Core::Engine.routes.find_script_name({})
+        mount_point += "/" unless mount_point.end_with?("/")
+        mount_point
       end
 
       def engine


### PR DESCRIPTION
## Summary

Solidus might not be mounted at /, the extensions need to reflect the install mount point of Solidus.


## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
