### PR TITLE
Add partial support for v4 intents payment sources

### DIFF
--- a/app/decorators/models/solidus_stripe/spree/credit_card_decorator.rb
+++ b/app/decorators/models/solidus_stripe/spree/credit_card_decorator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SolidusStripe
+  module Spree
+    module CreditCard
+      # Support for partial backward compatibility with solidus_stripe v5 if Payment Intents API was used in v4
+      # Allows continued use of v4 credit cards saved in user's wallet_payment_sources
+      # Cannot create a new v4 payment source
+
+      def stripe_customer_id
+        gateway_customer_profile_id
+      end
+
+      def stripe_payment_method_id
+        gateway_payment_profile_id
+      end
+
+      def stripe_payment_method
+        return if stripe_payment_method_id.blank?
+
+        @stripe_payment_method ||= payment_method.gateway.request do
+          ::Stripe::PaymentMethod.retrieve(stripe_payment_method_id)
+        end
+      end
+
+      def v4?
+        true
+      end
+
+      ::Spree::CreditCard.prepend self
+    end
+  end
+end

--- a/app/models/solidus_stripe/payment_source.rb
+++ b/app/models/solidus_stripe/payment_source.rb
@@ -27,5 +27,9 @@ module SolidusStripe
     def can_credit?(payment)
       payment.completed? && payment.credit_allowed > 0
     end
+
+    def v4?
+      false
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR tries to add support for the continued use of v4 payment sources saved in `wallet_payment_sources` as "existing payments." The code is more of a proof of concept so I want to present this PR as a draft.

Currently v4 payment sources cannot be reused and this makes it difficult for stores to migrate to v5 if they have already implemented v4 in production. This PR aims to resolve that. 

I believe the support is only applicable for stores that used Stripe Payment Intents API with the `v3_intents` option enabled, but I'm not entirely sure.
It does not support creation of new v4 payment sources.
It only allows reuse of cards saved in `wallet_payment_sources`.

I am well aware that v5 is a complete rewrite, and I believe the core team doesn't want code supporting legacy versions creeping into various parts of the code base. Still, I wanted to see if there is any way something like this can be implemented at the gem level. Also, I would like to kindly ask if the reuse of v4 payment sources are done in a correct way. 

I hope this PR can provide easier migration path for existing users of this wonderful gem.

Thank you for reviewing this PR and I appreciate any comments or suggestions🙏

## Update

I realized that what I described in this PR requires the `payment_method_id` to be the same for both v4 and v5. So this PR will not work when a payment method is added instead of updated from v4.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [X] I have written a thorough PR description.
- [X] I have kept my commits small and atomic.
- [X] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
